### PR TITLE
perf: document hot-path allocation ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ operate without guessing which config file or pid file is active.
 | HTTP/3 rollout and lifecycle | [docs/HTTP3_ROLLOUT.md](docs/HTTP3_ROLLOUT.md) |
 | HTTP/3 validation evidence | [docs/HTTP3_VALIDATION_EVIDENCE.md](docs/HTTP3_VALIDATION_EVIDENCE.md) |
 | Concurrency & hot-path audit | [docs/CONCURRENCY.md](docs/CONCURRENCY.md) |
+| Hot-path allocation ownership | [docs/ALLOCATION_OWNERSHIP.md](docs/ALLOCATION_OWNERSHIP.md) |
 | Event-loop backend evaluation (epoll/kqueue vs libxev/std.Io/io_uring) | [docs/EVENT_LOOP_BACKENDS.md](docs/EVENT_LOOP_BACKENDS.md) |
 | Observability | [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) |
 | Reload, drain, and shutdown | [docs/RELOAD_SHUTDOWN.md](docs/RELOAD_SHUTDOWN.md) |

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -110,7 +110,8 @@ Current debug budgets:
 | `static-tiny-file-warm` | 14 | 1024 | File-backed warm static responses allocate normalized path metadata, ETag, and Last-Modified strings; file bytes stay out of heap. |
 | `static-304-conditional` | 14 | 1024 | Conditional static hits follow the same path and validator allocation shape, but avoid response-body bytes. |
 | `proxy-keepalive-warm` | 6 | 512 | Warm proxy keep-alive helper work owns resolved target strings while forwarded header assembly stays stack-backed. |
-| `proxy-header-heavy-response` | 0 | 0 | Header-heavy streamed proxy response rewriting borrows upstream header slices and formats into caller-owned output; hop-by-hop and disclosure headers are filtered without heap ownership. |
+| `proxy-header-heavy-response` | 16 | 2048 | Header-heavy buffered proxy response parsing owns filtered metadata in an arena; serialization writes through caller-owned buffers. |
+| `mixed-route-selection` | 0 | 0 | Mixed route selection borrows immutable config-owned location blocks and allocates no request memory. |
 | `rejected-overload` | 12 | 1024 | This intentionally allocating path builds a structured JSON error and response header copies before closing the request. |
 
 Large streamed proxy-response allocation checks belong with live throughput and

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -111,7 +111,11 @@ Current debug budgets:
 | `static-304-conditional` | 14 | 1024 | Conditional static hits follow the same path and validator allocation shape, but avoid response-body bytes. |
 | `proxy-keepalive-warm` | 6 | 512 | Warm proxy keep-alive helper work owns resolved target strings while forwarded header assembly stays stack-backed. |
 | `proxy-header-heavy-response` | 16 | 2048 | Header-heavy buffered proxy response parsing owns filtered metadata in an arena; serialization writes through caller-owned buffers. |
-| `mixed-route-selection` | 12 | 1024 | Mixed route selection borrows config-owned location blocks; regex scratch is request-allocator-owned while POSIX `regcomp` remains an external libc boundary. |
+| `mixed-route-exact` | 0 | 0 | Exact route selection borrows config-owned location blocks and returns before regex evaluation. |
+| `mixed-route-priority` | 0 | 0 | Priority-prefix route selection borrows config-owned location blocks and returns before regex evaluation. |
+| `mixed-route-regex` | 12 | 1024 | Regex route selection borrows config-owned location blocks; regex scratch is request-allocator-owned while POSIX `regcomp` remains an external libc boundary. |
+| `mixed-route-prefix-after-regex` | 12 | 1024 | Plain-prefix route selection after a non-matching regex pays request-owned regex scratch before returning the borrowed prefix match. |
+| `h1-regex-route-arena-reset` | 4 | 4096 | Production-shaped H1 regex route scratch is retained by the request arena until request completion, then arena deinit releases backing storage. |
 | `rejected-overload` | 12 | 1024 | This intentionally allocating path builds a structured JSON error and response header copies before closing the request. |
 
 Large streamed proxy-response allocation checks belong with live throughput and

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -110,12 +110,16 @@ Current debug budgets:
 | `static-tiny-file-warm` | 14 | 1024 | File-backed warm static responses allocate normalized path metadata, ETag, and Last-Modified strings; file bytes stay out of heap. |
 | `static-304-conditional` | 14 | 1024 | Conditional static hits follow the same path and validator allocation shape, but avoid response-body bytes. |
 | `proxy-keepalive-warm` | 6 | 512 | Warm proxy keep-alive helper work owns resolved target strings while forwarded header assembly stays stack-backed. |
+| `proxy-header-heavy-response` | 0 | 0 | Header-heavy streamed proxy response rewriting borrows upstream header slices and formats into caller-owned output; hop-by-hop and disclosure headers are filtered without heap ownership. |
 | `rejected-overload` | 12 | 1024 | This intentionally allocating path builds a structured JSON error and response header copies before closing the request. |
 
 Large streamed proxy-response allocation checks belong with live throughput and
 RSS benchmarks because they exercise socket backpressure rather than isolated
 helper allocation counts. Use the streaming scenarios below with PID sampling
 to compare RSS, p99, throughput, buffered bytes, and CPU.
+
+The ownership and reset-boundary audit behind these budgets is checked in at
+[docs/ALLOCATION_OWNERSHIP.md](../docs/ALLOCATION_OWNERSHIP.md).
 
 ## Scenarios
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -111,7 +111,7 @@ Current debug budgets:
 | `static-304-conditional` | 14 | 1024 | Conditional static hits follow the same path and validator allocation shape, but avoid response-body bytes. |
 | `proxy-keepalive-warm` | 6 | 512 | Warm proxy keep-alive helper work owns resolved target strings while forwarded header assembly stays stack-backed. |
 | `proxy-header-heavy-response` | 16 | 2048 | Header-heavy buffered proxy response parsing owns filtered metadata in an arena; serialization writes through caller-owned buffers. |
-| `mixed-route-selection` | 0 | 0 | Mixed route selection borrows immutable config-owned location blocks and allocates no request memory. |
+| `mixed-route-selection` | 12 | 1024 | Mixed route selection borrows config-owned location blocks; regex scratch is request-allocator-owned while POSIX `regcomp` remains an external libc boundary. |
 | `rejected-overload` | 12 | 1024 | This intentionally allocating path builds a structured JSON error and response header copies before closing the request. |
 
 Large streamed proxy-response allocation checks belong with live throughput and

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -114,7 +114,7 @@ Current debug budgets:
 | `mixed-route-exact` | 0 | 0 | Exact route selection borrows config-owned location blocks and returns before regex evaluation. |
 | `mixed-route-priority` | 0 | 0 | Priority-prefix route selection borrows config-owned location blocks and returns before regex evaluation. |
 | `mixed-route-regex` | 12 | 1024 | Regex route selection borrows config-owned location blocks; regex scratch is request-allocator-owned while POSIX `regcomp` remains an external libc boundary. |
-| `mixed-route-prefix-after-regex` | 12 | 1024 | Plain-prefix route selection after a non-matching regex pays request-owned regex scratch before returning the borrowed prefix match. |
+| `mixed-route-prefix-after-regex` | 0 | 0 | Plain-prefix route selection after an anchored literal regex miss skips regex scratch and returns borrowed config-owned locations. |
 | `h1-regex-route-arena-reset` | 4 | 4096 | Production-shaped H1 regex route scratch is retained by the request arena until request completion, then arena deinit releases backing storage. |
 | `rejected-overload` | 12 | 1024 | This intentionally allocating path builds a structured JSON error and response header copies before closing the request. |
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -114,7 +114,7 @@ Current debug budgets:
 | `mixed-route-exact` | 0 | 0 | Exact route selection borrows config-owned location blocks and returns before regex evaluation. |
 | `mixed-route-priority` | 0 | 0 | Priority-prefix route selection borrows config-owned location blocks and returns before regex evaluation. |
 | `mixed-route-regex` | 12 | 1024 | Regex route selection borrows config-owned location blocks; regex scratch is request-allocator-owned while POSIX `regcomp` remains an external libc boundary. |
-| `mixed-route-prefix-after-regex` | 0 | 0 | Plain-prefix route selection after an anchored literal regex miss skips regex scratch and returns borrowed config-owned locations. |
+| `mixed-route-prefix-after-regex` | 0 | 0 | Plain-prefix route selection after a case-sensitive anchored literal regex miss skips regex scratch and returns borrowed config-owned locations. |
 | `h1-regex-route-arena-reset` | 4 | 4096 | Production-shaped H1 regex route scratch is retained by the request arena until request completion, then arena deinit releases backing storage. |
 | `rejected-overload` | 12 | 1024 | This intentionally allocating path builds a structured JSON error and response header copies before closing the request. |
 

--- a/docs/ALLOCATION_OWNERSHIP.md
+++ b/docs/ALLOCATION_OWNERSHIP.md
@@ -26,9 +26,9 @@ route matching:
   instead of relying on an allocator-free serializer alone.
 - The four `mixed-route-*` rows cover one route lookup per reported request
   class: exact match, priority prefix, regex match, and plain-prefix return
-  after an anchored literal regex miss. They return borrowed route slices, but
+  after a case-sensitive anchored literal regex miss. They return borrowed route slices, but
   regex evaluation requires request-owned Zig scratch. This audit makes that
-  scratch allocator-aware and budgeted; anchored literal misses skip full regex
+  scratch allocator-aware and budgeted; case-sensitive anchored literal misses skip full regex
   preparation before `regcomp`, and POSIX `regcomp` may still allocate through
   libc outside the Zig allocator interface.
 - `h1-regex-route-arena-reset` models the production HTTP/1 request arena by
@@ -146,7 +146,7 @@ benchmarks/run.sh --duration 5 --connections 4 --threads 1 --tool wrk \
 The `regex-match` path returns from the regex location and exercises the
 request-owned regex scratch path. The initial 5s `prefix-after-regex` sample
 showed noisy tail latency after moving scratch into the request allocator, so
-the matcher now performs a conservative anchored-literal prefix check before
+the matcher now performs a conservative case-sensitive anchored-literal prefix check before
 full regex preparation. A repeated run then measured the affected
 plain-prefix-after-nonmatching-regex shape with 5 independent 15s samples per
 build:
@@ -164,7 +164,7 @@ benchmarks/run.sh --duration 15 --connections 4 --threads 1 --tool wrk \
 | base | 24553.11 (22252.61-25018.83) | 0.386 (0.348-0.619) | 3.177 (1.201-12.082) | 169.19 (160.03-170.09) | 5.09 (5.00-5.69) | 0 |
 | head | 24937.52 (23197.48-25110.12) | 0.456 (0.387-0.497) | 2.908 (1.636-65.429) | 146.02 (141.59-147.13) | 4.69 (4.59-5.39) | 0 |
 
-After the anchored-literal miss fast path, the deterministic allocation row for
+After the case-sensitive anchored-literal miss fast path, the deterministic allocation row for
 this shape is `0.00` allocations and `0.00` bytes per request. The repeated live
 run no longer reproduces the original p999 regression by median; p99 remains in
 the same local-run band with overlapping ranges, while throughput, sampled CPU,
@@ -236,7 +236,7 @@ is not used as quantitative evidence.
 | Forwarded request header vector | Worker/request scratch | `stackFallback` storage is released when header assembly returns; heap fallback is freed by `ArrayList.deinit` | Existing bounded stack fallback is the right reuse mechanism. The warm proxy scenario confirms forwarded headers remain stack-backed. |
 | Proxy trusted-identity derived header values | Request-owned | Freed with the request's owned header value list after upstream dispatch completes | Direct allocation is retained because values include per-request timestamp/signature material and cannot be shared with connection-owned pools. |
 | Exact and priority-prefix server/location matching | Process/config-owned metadata plus borrowed request URI path | Matching returns before dispatch; matched route slices remain tied to the config snapshot | No request workspace is needed. The `mixed-route-exact` and `mixed-route-priority` rows enforce zero request-allocator churn for the request classes that return before regex evaluation. |
-| H1 regex server/location matching | Process/config-owned metadata plus request-arena regex scratch | Logical regex scratch frees occur before match return, but the H1 request arena retains backing capacity until `handleConnection` request-arena deinit | Direct request-arena scratch is retained for actual regex evaluation. The `mixed-route-regex` row records logical scratch churn for one matcher invocation/request class, while `mixed-route-prefix-after-regex` proves an anchored literal miss can return the borrowed prefix match without request-allocator churn. `h1-regex-route-arena-reset` models two route resolutions in one H1 request and proves backing storage returns to zero live bytes only after request completion. POSIX `regcomp` remains an external libc allocation boundary; precompiled config-owned regexes are a future targeted optimization if regex-heavy routing becomes material. |
+| H1 regex server/location matching | Process/config-owned metadata plus request-arena regex scratch | Logical regex scratch frees occur before match return, but the H1 request arena retains backing capacity until `handleConnection` request-arena deinit | Direct request-arena scratch is retained for actual regex evaluation. The `mixed-route-regex` row records logical scratch churn for one matcher invocation/request class, while `mixed-route-prefix-after-regex` proves a case-sensitive anchored literal miss can return the borrowed prefix match without request-allocator churn. `h1-regex-route-arena-reset` models two route resolutions in one H1 request and proves backing storage returns to zero live bytes only after request completion. POSIX `regcomp` remains an external libc allocation boundary; precompiled config-owned regexes are a future targeted optimization if regex-heavy routing becomes material. |
 | H2/H3 regex server/location matching | Allocator supplied by the H2/H3 dispatch path plus process/config-owned metadata | Reset follows the supplied allocator's owner, not the route matcher call itself | The matcher is allocator-aware, so H2/H3 callers account scratch against their dispatch allocator. They must not assume a universal match-scoped physical release boundary. |
 | Buffered proxy response body | Request-owned, with aggregate proxy-buffer accounting | Released after downstream write completion, abort cleanup, or local capacity failure handling | Existing accounting and streaming fallback rules are the safety mechanism. Reusing this memory in a request arena would risk hiding retained bytes from proxy buffer limits. |
 | HTTP/1 streaming relay buffer and response-head arena | Request/proxy-attempt-owned | Released when `streamProxyOverTransport` returns after body relay, abort cleanup, or local capacity failure handling | A request workspace must not reset at response-head generation because the relay buffer and parsed head arena live through the full streaming attempt. They may reset after the attempt completes. |

--- a/docs/ALLOCATION_OWNERSHIP.md
+++ b/docs/ALLOCATION_OWNERSHIP.md
@@ -24,8 +24,10 @@ The audit adds two deterministic harness rows:
   caller-owned output. This makes the arena-owned response metadata observable
   instead of relying on an allocator-free serializer alone.
 - `mixed-route-selection` covers request-metadata-heavy location matching over
-  process/config-owned route blocks. It has a zero-allocation budget because
-  `matchLocation` returns borrowed slices into immutable config.
+  process/config-owned route blocks. It returns borrowed route slices, but regex
+  locations require request-owned scratch. This audit makes that Zig scratch
+  allocator-aware and budgeted; POSIX `regcomp` may still allocate through libc
+  outside the Zig allocator interface.
 
 The after run reported:
 
@@ -35,8 +37,17 @@ The after run reported:
 | `static-304-conditional` | 13.00 | 779.00 | 311 |
 | `proxy-keepalive-warm` | 6.00 | 410.00 | 239 |
 | `proxy-header-heavy-response` | 4.00 | 1742.00 | 1742 |
-| `mixed-route-selection` | 0.00 | 0.00 | 0 |
+| `mixed-route-selection` | 8.00 | 356.00 | 146 |
 | `rejected-overload` | 12.00 | 716.00 | 407 |
+
+For the newly added audit rows, `proxy-header-heavy-response` is comparable to
+base when the helper is applied there because it exercises existing buffered
+proxy response parsing. `mixed-route-selection` exposed a non-comparable base
+instrumentation gap: before this fix, regex matching used
+`std.heap.page_allocator`, so the harness could not observe Zig regex scratch at
+all. The head row above is the first allocator-visible budget for that route
+class; it records the now request-allocator-owned Zig scratch while still
+documenting the external libc `regcomp` boundary.
 
 No reusable workspace or pool was introduced, so there is no workspace
 high-water mark, fallback count, or retained capacity contract to report.
@@ -63,18 +74,39 @@ benchmarks/ci-smoke.sh --duration 5 --connections 4 --threads 1 --save <file>
 | `keepalive` | base | 42553.87 | 0.230 | 3.143 | 302.97 | 5.28 | 0 |
 | `keepalive` | head | 39439.34 | 0.233 | 1.872 | 293.77 | 5.20 | 0 |
 
-Large streaming proxy command shape:
+Large streaming proxy server config:
+
+```nginx
+pid /tmp/issue143-<build>/tardi.pid;
+listen <port>;
+metrics_path /status/metrics;
+
+location = /health {
+    return 200 ok;
+}
+
+location /proxy/ {
+    proxy_pass http://127.0.0.1:<upstream-port>;
+    proxy_streaming response;
+}
+```
+
+Large streaming proxy launch and benchmark shape:
 
 ```bash
-TARDIGRADE_PROXY_STREAMING_MODE=response \
+TARDIGRADE_RATE_LIMIT_RPS=0 \
+TARDIGRADE_MAX_REQUESTS_PER_CONNECTION=0 \
 TARDIGRADE_UPSTREAM_RETRY_ATTEMPTS=1 \
+./zig-out/bin/tardi run -c /tmp/issue143-<build>/tardigrade.conf &
+pid=$!
+
 benchmarks/run.sh --duration 5 --connections 2 --threads 1 \
   --proxy-payload-1m-path /proxy/payload-1m.bin \
   --proxy-slow-client-path /proxy/payload-16m.bin \
   --slow-client-connections 2 \
   --slow-client-limit-rate 2M \
   --scenarios proxy-payload-1m,proxy-slow-client-download \
-  --pid <tardigrade-pid>
+  --pid "$pid"
 ```
 
 | Scenario | Build | req/s | p99 ms | p999 ms | CPU % | Peak RSS MiB | Errors |
@@ -83,10 +115,15 @@ benchmarks/run.sh --duration 5 --connections 2 --threads 1 \
 | `proxy-payload-1m` | head | 3265.22 | 0.853 | 2.997 | 395236.62 | 6.14 | 2 |
 
 The 1 MiB row exercises the response-streaming proxy path with PID/RSS
-sampling. On this local fallback run, the benchmark driver reported two errors
-in both base and head, and the very short 5s macOS CPU sample produced
-unusable CPU percentages. The comparable p99/p999, throughput, and RSS rows are
-still recorded because they show no branch-specific ownership regression. The
+sampling. A single-request metric check against the same config produced
+`tardigrade_proxy_streaming_requests_total 1`,
+`tardigrade_proxy_buffered_requests_total 0`, and all
+`tardigrade_proxy_streaming_fallback_total{reason=...}` counters at `0` for
+both base and head, confirming the configured route selected the streaming path.
+On this local fallback run, the benchmark driver reported two errors in both
+base and head, and the very short 5s macOS CPU sample produced unusable CPU
+percentages. The comparable p99/p999, throughput, and RSS rows are still
+recorded because they show no branch-specific ownership regression. The
 `proxy-slow-client-download` row was attempted with the same config, but the
 driver reported only `errors=2` with null latency/CPU/RSS for both builds, so it
 is not used as quantitative evidence.
@@ -100,9 +137,10 @@ is not used as quantitative evidence.
 | Proxy target URL and optional query string | Request-owned | Freed before proxy dispatch helper completion, or by the request path before retry/keepalive state is released | Direct allocation is retained. These strings may be needed across retry/error handling for a single request but must not be retained by upstream connection pools. |
 | Forwarded request header vector | Worker/request scratch | `stackFallback` storage is released when header assembly returns; heap fallback is freed by `ArrayList.deinit` | Existing bounded stack fallback is the right reuse mechanism. The warm proxy scenario confirms forwarded headers remain stack-backed. |
 | Proxy trusted-identity derived header values | Request-owned | Freed with the request's owned header value list after upstream dispatch completes | Direct allocation is retained because values include per-request timestamp/signature material and cannot be shared with connection-owned pools. |
-| Mixed route selection and server/location matching | Process/config-owned metadata; borrowed request URI path | Matching returns before dispatch and does not allocate; matched route slices remain tied to the config snapshot | No request workspace. The `mixed-route-selection` harness row enforces zero request allocator churn for exact, prefix-priority, regex, and prefix selection. |
+| Mixed route selection and server/location matching | Process/config-owned metadata plus request-owned regex scratch | Matching returns before dispatch; matched route slices remain tied to the config snapshot, while regex pattern/input scratch is freed before match return | Direct request-allocator scratch is retained for regex routes. The `mixed-route-selection` harness row records 8 allocations/356 bytes per request for the representative exact, prefix-priority, regex, and prefix sequence. POSIX `regcomp` remains an external libc allocation boundary; precompiled config-owned regexes are a future targeted optimization if regex-heavy routing becomes material. |
 | Buffered proxy response body | Request-owned, with aggregate proxy-buffer accounting | Released after downstream write completion, abort cleanup, or local capacity failure handling | Existing accounting and streaming fallback rules are the safety mechanism. Reusing this memory in a request arena would risk hiding retained bytes from proxy buffer limits. |
-| Streaming proxy relay buffers | Connection/stream-owned | Released when the streaming transfer completes, aborts, or the owning H2/H3 stream/connection closes | Must not move into request-reset memory. Backpressure queues and stream state can retain buffers after response headers are generated. |
+| HTTP/1 streaming relay buffer and response-head arena | Request/proxy-attempt-owned | Released when `streamProxyOverTransport` returns after body relay, abort cleanup, or local capacity failure handling | A request workspace must not reset at response-head generation because the relay buffer and parsed head arena live through the full streaming attempt. They may reset after the attempt completes. |
+| HTTP/2 stream receive queues and connection backpressure state | Stream/connection-owned | Queue drain, stream close/reset, connection close, or pool teardown | Never point these structures into request-reset memory. They can outlive a request-local header-generation phase and are independently accounted. |
 | Upstream connection pool entries | Connection-owned | Pool eviction, stale retry cleanup, or gateway shutdown | Not a request workspace candidate. Idle keepalive connections intentionally outlive individual requests. |
 | Overload/error JSON and response headers | Request-owned | Freed after the rejection response is written and the request is closed | Direct allocation is acceptable because this is not a success hot path and produces structured operator/client errors. |
 | Security header config, route config, add-header config, Alt-Svc | Process/config-owned | Config snapshot replacement or shutdown | Not reset by requests. Runtime response formatting borrows these immutable slices. |
@@ -115,7 +153,9 @@ For request-owned memory, the safe reset point is after all of the following are
 complete:
 
 - response bytes that reference the memory have been written or abandoned;
-- streaming proxy state has either taken ownership of its own buffers or has
+- HTTP/1 streaming proxy attempts have completed body relay/abort cleanup and
+  released request-owned relay/head memory;
+- H2/H3 streaming state has either taken ownership of its own buffers or has
   been torn down;
 - upstream retry/error cleanup has completed;
 - access logging, metrics, and tracing callbacks have consumed any borrowed

--- a/docs/ALLOCATION_OWNERSHIP.md
+++ b/docs/ALLOCATION_OWNERSHIP.md
@@ -1,0 +1,93 @@
+# Hot-Path Allocation Ownership
+
+Issue #143 reconciles allocation ownership for the general HTTP and reverse-proxy
+runtime. The allocation counter harness from issue #155 remains the source of
+deterministic hot-path allocation budgets; this note records what owns each
+meaningful allocation class, when it may be released, and why the current
+measurements do not justify a broad request arena.
+
+## Measured Scenarios
+
+`zig build bench-allocations` on `main` before this audit reported:
+
+| Scenario | Allocations/request | Bytes/request | Peak live bytes |
+| --- | ---: | ---: | ---: |
+| `static-tiny-file-warm` | 13.00 | 779.00 | 311 |
+| `static-304-conditional` | 13.00 | 779.00 | 311 |
+| `proxy-keepalive-warm` | 6.00 | 410.00 | 239 |
+| `rejected-overload` | 12.00 | 716.00 | 407 |
+
+The audit adds `proxy-header-heavy-response` to cover upstream response header
+filtering and downstream response-head assembly. That path has a zero-allocation
+budget because it borrows parsed upstream header slices and writes to a
+caller-owned output buffer. The after run reported:
+
+| Scenario | Allocations/request | Bytes/request | Peak live bytes |
+| --- | ---: | ---: | ---: |
+| `static-tiny-file-warm` | 13.00 | 779.00 | 311 |
+| `static-304-conditional` | 13.00 | 779.00 | 311 |
+| `proxy-keepalive-warm` | 6.00 | 410.00 | 239 |
+| `proxy-header-heavy-response` | 0.00 | 0.00 | 0 |
+| `rejected-overload` | 12.00 | 716.00 | 407 |
+
+No reusable workspace or pool was introduced, so there is no workspace
+high-water mark, fallback count, or retained capacity contract to report.
+Because runtime behavior did not change beyond a deterministic benchmark guard,
+latency, CPU/request, RSS, and p99/p999 risk is unchanged from the current
+benchmark suite; future runtime reuse changes must record those rows when they
+alter allocation ownership.
+
+## Ownership Inventory
+
+| Allocation class | Owner | Release/reset boundary | Reuse decision |
+| --- | --- | --- | --- |
+| Static normalized path, resolved path, cache validators | Request-owned | `StaticServed.deinit` after file response selection/serialization has completed | Direct allocation is retained. Slices are exposed through `StaticServed`, and the current 13 allocations/779 bytes per request stay under the checked budget without a safe common arena boundary for file-backed response metadata. |
+| Static file bytes | Request-owned only for buffered static responses; file-backed warm path is OS/file owned | Buffered bodies are freed by `StaticServed.deinit`; file-backed responses close the file after write completion | No broad pooling. The warm tiny-file benchmark keeps file bytes out of heap by requiring `prefer_file_backed`. |
+| Proxy target URL and optional query string | Request-owned | Freed before proxy dispatch helper completion, or by the request path before retry/keepalive state is released | Direct allocation is retained. These strings may be needed across retry/error handling for a single request but must not be retained by upstream connection pools. |
+| Forwarded request header vector | Worker/request scratch | `stackFallback` storage is released when header assembly returns; heap fallback is freed by `ArrayList.deinit` | Existing bounded stack fallback is the right reuse mechanism. The warm proxy scenario confirms forwarded headers remain stack-backed. |
+| Proxy trusted-identity derived header values | Request-owned | Freed with the request's owned header value list after upstream dispatch completes | Direct allocation is retained because values include per-request timestamp/signature material and cannot be shared with connection-owned pools. |
+| Buffered proxy response body | Request-owned, with aggregate proxy-buffer accounting | Released after downstream write completion, abort cleanup, or local capacity failure handling | Existing accounting and streaming fallback rules are the safety mechanism. Reusing this memory in a request arena would risk hiding retained bytes from proxy buffer limits. |
+| Streaming proxy relay buffers | Connection/stream-owned | Released when the streaming transfer completes, aborts, or the owning H2/H3 stream/connection closes | Must not move into request-reset memory. Backpressure queues and stream state can retain buffers after response headers are generated. |
+| Upstream connection pool entries | Connection-owned | Pool eviction, stale retry cleanup, or gateway shutdown | Not a request workspace candidate. Idle keepalive connections intentionally outlive individual requests. |
+| Overload/error JSON and response headers | Request-owned | Freed after the rejection response is written and the request is closed | Direct allocation is acceptable because this is not a success hot path and produces structured operator/client errors. |
+| Security header config, route config, add-header config, Alt-Svc | Process/config-owned | Config snapshot replacement or shutdown | Not reset by requests. Runtime response formatting borrows these immutable slices. |
+| HTTP/2 stream queues, HTTP/3/QPACK state, TLS encrypted-stream buffers | Connection/stream-owned | Stream close, connection close, or protocol-specific teardown | Excluded from request arenas. These owners have independent async/backpressure lifetimes. |
+| Access log, metrics, and tracing label values | Borrowed/caller-owned or process-owned | Logging/metrics calls complete after response construction but before request storage could be reused | Request memory must remain valid through logging and metrics emission. Long-lived metrics labels must come from process/config-owned constants. |
+
+## Reset Boundary
+
+For request-owned memory, the safe reset point is after all of the following are
+complete:
+
+- response bytes that reference the memory have been written or abandoned;
+- streaming proxy state has either taken ownership of its own buffers or has
+  been torn down;
+- upstream retry/error cleanup has completed;
+- access logging, metrics, and tracing callbacks have consumed any borrowed
+  request fields;
+- the downstream keepalive connection has been parked without retaining request
+  slices.
+
+"Application response selected" is not a sufficient reset boundary. The
+observable boundary is request lifecycle completion after write, cleanup, and
+post-response accounting.
+
+## Strategy
+
+No broad request arena is introduced. The measured direct allocations are small,
+already budgeted, and several classes have lifetimes that either cross the write
+boundary or are owned by connection/stream state. The existing targeted
+mechanisms match the actual owners:
+
+- `stackFallback` for proxy request header scratch;
+- fixed, bounded buffer pools for uniform reusable byte buffers;
+- proxy buffer accounting for retained body/relay allocations;
+- process/config-owned immutable slices for route/security/header policy;
+- direct allocations for rare rejection/error payloads and small request-local
+  strings.
+
+The benchmark addition in `src/allocation_regression.zig` makes the
+header-heavy proxy response path explicit and enforces that response header
+filtering stays allocation-free. Any future workspace or pool should be added
+only when a measured scenario shows material allocator churn and the owner has a
+single reset boundary.

--- a/docs/ALLOCATION_OWNERSHIP.md
+++ b/docs/ALLOCATION_OWNERSHIP.md
@@ -26,10 +26,11 @@ route matching:
   instead of relying on an allocator-free serializer alone.
 - The four `mixed-route-*` rows cover one route lookup per reported request
   class: exact match, priority prefix, regex match, and plain-prefix return
-  after a non-matching regex scan. They return borrowed route slices, but regex
-  evaluation requires request-owned Zig scratch. This audit makes that scratch
-  allocator-aware and budgeted; POSIX `regcomp` may still allocate through libc
-  outside the Zig allocator interface.
+  after an anchored literal regex miss. They return borrowed route slices, but
+  regex evaluation requires request-owned Zig scratch. This audit makes that
+  scratch allocator-aware and budgeted; anchored literal misses skip full regex
+  preparation before `regcomp`, and POSIX `regcomp` may still allocate through
+  libc outside the Zig allocator interface.
 - `h1-regex-route-arena-reset` models the production HTTP/1 request arena by
   putting the counter under an arena, performing two regex route resolutions in
   one request lifecycle, and asserting the backing allocator returns to zero
@@ -46,7 +47,7 @@ The after run reported:
 | `mixed-route-exact` | 0.00 | 0.00 | 0 |
 | `mixed-route-priority` | 0.00 | 0.00 | 0 |
 | `mixed-route-regex` | 4.00 | 181.00 | 146 |
-| `mixed-route-prefix-after-regex` | 4.00 | 175.00 | 146 |
+| `mixed-route-prefix-after-regex` | 0.00 | 0.00 | 0 |
 | `h1-regex-route-arena-reset` | 1.00 | 256.00 | 256 |
 | `rejected-overload` | 12.00 | 716.00 | 407 |
 
@@ -63,9 +64,11 @@ For mixed routing, base has an instrumentation boundary: before this fix, regex
 matching used `std.heap.page_allocator`, so the harness could not observe Zig
 regex scratch through the request allocator. The head route rows above are the
 first allocator-visible budgets for those request classes. Exact and
-priority-prefix requests still avoid regex scratch entirely; regex match and
-prefix-after-regex requests record the now request-allocator-owned Zig scratch
-while still documenting the external libc `regcomp` boundary.
+priority-prefix requests still avoid regex scratch entirely; anchored literal
+regex misses now skip full regex preparation before `regcomp`, so the
+prefix-after-regex row also stays at zero allocator churn. Regex matches record
+the now request-allocator-owned Zig scratch while still documenting the external
+libc `regcomp` boundary.
 
 No reusable workspace or pool was introduced, so there is no workspace
 high-water mark, fallback count, or retained capacity contract to report.
@@ -139,14 +142,35 @@ benchmarks/run.sh --duration 5 --connections 4 --threads 1 --tool wrk \
 | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
 | `regex-match` | base | `/regex/health` | 18912.18 | 5.261 | 14.807 | 133.20 | 5.52 | 0 |
 | `regex-match` | head | `/regex/health` | 22493.27 | 2.849 | 10.331 | 127.82 | 5.55 | 0 |
-| `prefix-after-regex` | base | `/prefix/health` | 23162.59 | 0.594 | 6.245 | 173.15 | 5.56 | 0 |
-| `prefix-after-regex` | head | `/prefix/health` | 24765.01 | 0.749 | 7.731 | 144.61 | 5.48 | 0 |
 
-These two rows exercise the runtime matcher branch changed by this audit. The
-`regex-match` path returns from the regex location. The `prefix-after-regex`
-path evaluates a non-matching regex first, then returns the borrowed plain
-prefix location. CPU is the benchmark runner's short macOS PID sample, so it is
-recorded as local fallback evidence rather than a canonical release baseline.
+The `regex-match` path returns from the regex location and exercises the
+request-owned regex scratch path. The initial 5s `prefix-after-regex` sample
+showed noisy tail latency after moving scratch into the request allocator, so
+the matcher now performs a conservative anchored-literal prefix check before
+full regex preparation. A repeated run then measured the affected
+plain-prefix-after-nonmatching-regex shape with 5 independent 15s samples per
+build:
+
+```bash
+benchmarks/run.sh --duration 15 --connections 4 --threads 1 --tool wrk \
+  --scenarios proxy-http1 \
+  --proxy-path /prefix/health \
+  --pid "$pid" \
+  --save prefix-<build>-<run>.json
+```
+
+| Build | req/s median (min-max) | p99 ms median (min-max) | p999 ms median (min-max) | CPU % median (min-max) | Peak RSS MiB median (min-max) | Errors |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| base | 24553.11 (22252.61-25018.83) | 0.386 (0.348-0.619) | 3.177 (1.201-12.082) | 169.19 (160.03-170.09) | 5.09 (5.00-5.69) | 0 |
+| head | 24937.52 (23197.48-25110.12) | 0.456 (0.387-0.497) | 2.908 (1.636-65.429) | 146.02 (141.59-147.13) | 4.69 (4.59-5.39) | 0 |
+
+After the anchored-literal miss fast path, the deterministic allocation row for
+this shape is `0.00` allocations and `0.00` bytes per request. The repeated live
+run no longer reproduces the original p999 regression by median; p99 remains in
+the same local-run band with overlapping ranges, while throughput, sampled CPU,
+and RSS are neutral-to-better on head. CPU and p999 are still short local macOS
+PID/wrk samples and are recorded as fallback evidence rather than canonical
+release-baseline numbers.
 
 Large streaming proxy server config:
 
@@ -212,7 +236,7 @@ is not used as quantitative evidence.
 | Forwarded request header vector | Worker/request scratch | `stackFallback` storage is released when header assembly returns; heap fallback is freed by `ArrayList.deinit` | Existing bounded stack fallback is the right reuse mechanism. The warm proxy scenario confirms forwarded headers remain stack-backed. |
 | Proxy trusted-identity derived header values | Request-owned | Freed with the request's owned header value list after upstream dispatch completes | Direct allocation is retained because values include per-request timestamp/signature material and cannot be shared with connection-owned pools. |
 | Exact and priority-prefix server/location matching | Process/config-owned metadata plus borrowed request URI path | Matching returns before dispatch; matched route slices remain tied to the config snapshot | No request workspace is needed. The `mixed-route-exact` and `mixed-route-priority` rows enforce zero request-allocator churn for the request classes that return before regex evaluation. |
-| H1 regex server/location matching | Process/config-owned metadata plus request-arena regex scratch | Logical regex scratch frees occur before match return, but the H1 request arena retains backing capacity until `handleConnection` request-arena deinit | Direct request-arena scratch is retained. The `mixed-route-regex` and `mixed-route-prefix-after-regex` rows record logical scratch churn for one matcher invocation/request class; `h1-regex-route-arena-reset` models two route resolutions in one H1 request and proves backing storage returns to zero live bytes only after request completion. POSIX `regcomp` remains an external libc allocation boundary; precompiled config-owned regexes are a future targeted optimization if regex-heavy routing becomes material. |
+| H1 regex server/location matching | Process/config-owned metadata plus request-arena regex scratch | Logical regex scratch frees occur before match return, but the H1 request arena retains backing capacity until `handleConnection` request-arena deinit | Direct request-arena scratch is retained for actual regex evaluation. The `mixed-route-regex` row records logical scratch churn for one matcher invocation/request class, while `mixed-route-prefix-after-regex` proves an anchored literal miss can return the borrowed prefix match without request-allocator churn. `h1-regex-route-arena-reset` models two route resolutions in one H1 request and proves backing storage returns to zero live bytes only after request completion. POSIX `regcomp` remains an external libc allocation boundary; precompiled config-owned regexes are a future targeted optimization if regex-heavy routing becomes material. |
 | H2/H3 regex server/location matching | Allocator supplied by the H2/H3 dispatch path plus process/config-owned metadata | Reset follows the supplied allocator's owner, not the route matcher call itself | The matcher is allocator-aware, so H2/H3 callers account scratch against their dispatch allocator. They must not assume a universal match-scoped physical release boundary. |
 | Buffered proxy response body | Request-owned, with aggregate proxy-buffer accounting | Released after downstream write completion, abort cleanup, or local capacity failure handling | Existing accounting and streaming fallback rules are the safety mechanism. Reusing this memory in a request arena would risk hiding retained bytes from proxy buffer limits. |
 | HTTP/1 streaming relay buffer and response-head arena | Request/proxy-attempt-owned | Released when `streamProxyOverTransport` returns after body relay, abort cleanup, or local capacity failure handling | A request workspace must not reset at response-head generation because the relay buffer and parsed head arena live through the full streaming attempt. They may reset after the attempt completes. |

--- a/docs/ALLOCATION_OWNERSHIP.md
+++ b/docs/ALLOCATION_OWNERSHIP.md
@@ -17,25 +17,79 @@ measurements do not justify a broad request arena.
 | `proxy-keepalive-warm` | 6.00 | 410.00 | 239 |
 | `rejected-overload` | 12.00 | 716.00 | 407 |
 
-The audit adds `proxy-header-heavy-response` to cover upstream response header
-filtering and downstream response-head assembly. That path has a zero-allocation
-budget because it borrows parsed upstream header slices and writes to a
-caller-owned output buffer. The after run reported:
+The audit adds two deterministic harness rows:
+
+- `proxy-header-heavy-response` routes allocation-capable production parsing
+  through the counting allocator, then serializes the filtered response through
+  caller-owned output. This makes the arena-owned response metadata observable
+  instead of relying on an allocator-free serializer alone.
+- `mixed-route-selection` covers request-metadata-heavy location matching over
+  process/config-owned route blocks. It has a zero-allocation budget because
+  `matchLocation` returns borrowed slices into immutable config.
+
+The after run reported:
 
 | Scenario | Allocations/request | Bytes/request | Peak live bytes |
 | --- | ---: | ---: | ---: |
 | `static-tiny-file-warm` | 13.00 | 779.00 | 311 |
 | `static-304-conditional` | 13.00 | 779.00 | 311 |
 | `proxy-keepalive-warm` | 6.00 | 410.00 | 239 |
-| `proxy-header-heavy-response` | 0.00 | 0.00 | 0 |
+| `proxy-header-heavy-response` | 4.00 | 1742.00 | 1742 |
+| `mixed-route-selection` | 0.00 | 0.00 | 0 |
 | `rejected-overload` | 12.00 | 716.00 | 407 |
 
 No reusable workspace or pool was introduced, so there is no workspace
 high-water mark, fallback count, or retained capacity contract to report.
-Because runtime behavior did not change beyond a deterministic benchmark guard,
-latency, CPU/request, RSS, and p99/p999 risk is unchanged from the current
-benchmark suite; future runtime reuse changes must record those rows when they
-alter allocation ownership.
+
+## Live Evidence
+
+Base and head release binaries were built from `main` and this branch and run on
+the same local macOS loopback host with PID sampling. These are local fallback
+rows, not canonical release-baseline numbers; they are included to record the
+latency/CPU/RSS shape for the ownership audit.
+
+CI-smoke command shape:
+
+```bash
+benchmarks/ci-smoke.sh --duration 5 --connections 4 --threads 1 --save <file>
+```
+
+| Scenario | Build | req/s | p99 ms | p999 ms | CPU % | Peak RSS MiB | Errors |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `static-http1` | base | 38147.35 | 0.284 | 3.228 | 285.11 | 4.94 | 0 |
+| `static-http1` | head | 42345.02 | 0.242 | 3.068 | 303.79 | 4.91 | 0 |
+| `proxy-http1` | base | 15011.66 | 0.934 | 2.823 | 116.20 | 5.27 | 0 |
+| `proxy-http1` | head | 15423.09 | 0.782 | 2.535 | 120.00 | 5.20 | 0 |
+| `keepalive` | base | 42553.87 | 0.230 | 3.143 | 302.97 | 5.28 | 0 |
+| `keepalive` | head | 39439.34 | 0.233 | 1.872 | 293.77 | 5.20 | 0 |
+
+Large streaming proxy command shape:
+
+```bash
+TARDIGRADE_PROXY_STREAMING_MODE=response \
+TARDIGRADE_UPSTREAM_RETRY_ATTEMPTS=1 \
+benchmarks/run.sh --duration 5 --connections 2 --threads 1 \
+  --proxy-payload-1m-path /proxy/payload-1m.bin \
+  --proxy-slow-client-path /proxy/payload-16m.bin \
+  --slow-client-connections 2 \
+  --slow-client-limit-rate 2M \
+  --scenarios proxy-payload-1m,proxy-slow-client-download \
+  --pid <tardigrade-pid>
+```
+
+| Scenario | Build | req/s | p99 ms | p999 ms | CPU % | Peak RSS MiB | Errors |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `proxy-payload-1m` | base | 3263.47 | 0.865 | 3.292 | 472341.51 | 5.89 | 2 |
+| `proxy-payload-1m` | head | 3265.22 | 0.853 | 2.997 | 395236.62 | 6.14 | 2 |
+
+The 1 MiB row exercises the response-streaming proxy path with PID/RSS
+sampling. On this local fallback run, the benchmark driver reported two errors
+in both base and head, and the very short 5s macOS CPU sample produced
+unusable CPU percentages. The comparable p99/p999, throughput, and RSS rows are
+still recorded because they show no branch-specific ownership regression. The
+`proxy-slow-client-download` row was attempted with the same config, but the
+driver reported only `errors=2` with null latency/CPU/RSS for both builds, so it
+is not used as quantitative evidence.
 
 ## Ownership Inventory
 
@@ -46,6 +100,7 @@ alter allocation ownership.
 | Proxy target URL and optional query string | Request-owned | Freed before proxy dispatch helper completion, or by the request path before retry/keepalive state is released | Direct allocation is retained. These strings may be needed across retry/error handling for a single request but must not be retained by upstream connection pools. |
 | Forwarded request header vector | Worker/request scratch | `stackFallback` storage is released when header assembly returns; heap fallback is freed by `ArrayList.deinit` | Existing bounded stack fallback is the right reuse mechanism. The warm proxy scenario confirms forwarded headers remain stack-backed. |
 | Proxy trusted-identity derived header values | Request-owned | Freed with the request's owned header value list after upstream dispatch completes | Direct allocation is retained because values include per-request timestamp/signature material and cannot be shared with connection-owned pools. |
+| Mixed route selection and server/location matching | Process/config-owned metadata; borrowed request URI path | Matching returns before dispatch and does not allocate; matched route slices remain tied to the config snapshot | No request workspace. The `mixed-route-selection` harness row enforces zero request allocator churn for exact, prefix-priority, regex, and prefix selection. |
 | Buffered proxy response body | Request-owned, with aggregate proxy-buffer accounting | Released after downstream write completion, abort cleanup, or local capacity failure handling | Existing accounting and streaming fallback rules are the safety mechanism. Reusing this memory in a request arena would risk hiding retained bytes from proxy buffer limits. |
 | Streaming proxy relay buffers | Connection/stream-owned | Released when the streaming transfer completes, aborts, or the owning H2/H3 stream/connection closes | Must not move into request-reset memory. Backpressure queues and stream state can retain buffers after response headers are generated. |
 | Upstream connection pool entries | Connection-owned | Pool eviction, stale retry cleanup, or gateway shutdown | Not a request workspace candidate. Idle keepalive connections intentionally outlive individual requests. |
@@ -86,8 +141,7 @@ mechanisms match the actual owners:
 - direct allocations for rare rejection/error payloads and small request-local
   strings.
 
-The benchmark addition in `src/allocation_regression.zig` makes the
-header-heavy proxy response path explicit and enforces that response header
-filtering stays allocation-free. Any future workspace or pool should be added
-only when a measured scenario shows material allocator churn and the owner has a
-single reset boundary.
+The benchmark additions in `src/allocation_regression.zig` make header-heavy
+proxy response metadata ownership and mixed route selection explicit. Any future
+workspace or pool should be added only when a measured scenario shows material
+allocator churn and the owner has a single reset boundary.

--- a/docs/ALLOCATION_OWNERSHIP.md
+++ b/docs/ALLOCATION_OWNERSHIP.md
@@ -17,17 +17,23 @@ measurements do not justify a broad request arena.
 | `proxy-keepalive-warm` | 6.00 | 410.00 | 239 |
 | `rejected-overload` | 12.00 | 716.00 | 407 |
 
-The audit adds two deterministic harness rows:
+The audit adds deterministic harness rows for header-heavy proxy parsing and
+route matching:
 
 - `proxy-header-heavy-response` routes allocation-capable production parsing
   through the counting allocator, then serializes the filtered response through
   caller-owned output. This makes the arena-owned response metadata observable
   instead of relying on an allocator-free serializer alone.
-- `mixed-route-selection` covers request-metadata-heavy location matching over
-  process/config-owned route blocks. It returns borrowed route slices, but regex
-  locations require request-owned scratch. This audit makes that Zig scratch
+- The four `mixed-route-*` rows cover one route lookup per reported request
+  class: exact match, priority prefix, regex match, and plain-prefix return
+  after a non-matching regex scan. They return borrowed route slices, but regex
+  evaluation requires request-owned Zig scratch. This audit makes that scratch
   allocator-aware and budgeted; POSIX `regcomp` may still allocate through libc
   outside the Zig allocator interface.
+- `h1-regex-route-arena-reset` models the production HTTP/1 request arena by
+  putting the counter under an arena, performing two regex route resolutions in
+  one request lifecycle, and asserting the backing allocator returns to zero
+  live bytes only after request-arena deinit.
 
 The after run reported:
 
@@ -37,17 +43,29 @@ The after run reported:
 | `static-304-conditional` | 13.00 | 779.00 | 311 |
 | `proxy-keepalive-warm` | 6.00 | 410.00 | 239 |
 | `proxy-header-heavy-response` | 4.00 | 1742.00 | 1742 |
-| `mixed-route-selection` | 8.00 | 356.00 | 146 |
+| `mixed-route-exact` | 0.00 | 0.00 | 0 |
+| `mixed-route-priority` | 0.00 | 0.00 | 0 |
+| `mixed-route-regex` | 4.00 | 181.00 | 146 |
+| `mixed-route-prefix-after-regex` | 4.00 | 175.00 | 146 |
+| `h1-regex-route-arena-reset` | 1.00 | 256.00 | 256 |
 | `rejected-overload` | 12.00 | 716.00 | 407 |
 
-For the newly added audit rows, `proxy-header-heavy-response` is comparable to
-base when the helper is applied there because it exercises existing buffered
-proxy response parsing. `mixed-route-selection` exposed a non-comparable base
-instrumentation gap: before this fix, regex matching used
-`std.heap.page_allocator`, so the harness could not observe Zig regex scratch at
-all. The head row above is the first allocator-visible budget for that route
-class; it records the now request-allocator-owned Zig scratch while still
-documenting the external libc `regcomp` boundary.
+The measurement-only header-heavy helper was also applied to a temporary
+`main` worktree, because it exercises existing buffered proxy parsing and does
+not depend on this branch's matcher changes:
+
+| Scenario | Build | Allocations/request | Bytes/request | Peak live bytes |
+| --- | --- | ---: | ---: | ---: |
+| `proxy-header-heavy-response` | base | 4.00 | 1742.00 | 1742 |
+| `proxy-header-heavy-response` | head | 4.00 | 1742.00 | 1742 |
+
+For mixed routing, base has an instrumentation boundary: before this fix, regex
+matching used `std.heap.page_allocator`, so the harness could not observe Zig
+regex scratch through the request allocator. The head route rows above are the
+first allocator-visible budgets for those request classes. Exact and
+priority-prefix requests still avoid regex scratch entirely; regex match and
+prefix-after-regex requests record the now request-allocator-owned Zig scratch
+while still documenting the external libc `regcomp` boundary.
 
 No reusable workspace or pool was introduced, so there is no workspace
 high-water mark, fallback count, or retained capacity contract to report.
@@ -73,6 +91,62 @@ benchmarks/ci-smoke.sh --duration 5 --connections 4 --threads 1 --save <file>
 | `proxy-http1` | head | 15423.09 | 0.782 | 2.535 | 120.00 | 5.20 | 0 |
 | `keepalive` | base | 42553.87 | 0.230 | 3.143 | 302.97 | 5.28 | 0 |
 | `keepalive` | head | 39439.34 | 0.233 | 1.872 | 293.77 | 5.20 | 0 |
+
+Regex route benchmark config:
+
+```nginx
+pid /tmp/issue143-regex-live-<build>/tardi.pid;
+listen <port>;
+metrics_path /status/metrics;
+
+location = /health {
+    return 200 ok;
+}
+
+location /regex/ {
+    proxy_pass http://127.0.0.1:<upstream-port>;
+}
+
+location ~ ^/regex/health$ {
+    proxy_pass http://127.0.0.1:<upstream-port>;
+}
+
+location ~ ^/assets/.+\.css$ {
+    proxy_pass http://127.0.0.1:<upstream-port>;
+}
+
+location /prefix/ {
+    proxy_pass http://127.0.0.1:<upstream-port>;
+}
+```
+
+Regex route benchmark command shape:
+
+```bash
+TARDIGRADE_RATE_LIMIT_RPS=0 \
+TARDIGRADE_MAX_REQUESTS_PER_CONNECTION=0 \
+TARDIGRADE_UPSTREAM_RETRY_ATTEMPTS=1 \
+./zig-out/bin/tardi run -c /tmp/issue143-regex-live-<build>/tardigrade.conf &
+pid=$!
+
+benchmarks/run.sh --duration 5 --connections 4 --threads 1 --tool wrk \
+  --scenarios proxy-http1 \
+  --proxy-path <path> \
+  --pid "$pid"
+```
+
+| Scenario | Build | Path | req/s | p99 ms | p999 ms | CPU % | Peak RSS MiB | Errors |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `regex-match` | base | `/regex/health` | 18912.18 | 5.261 | 14.807 | 133.20 | 5.52 | 0 |
+| `regex-match` | head | `/regex/health` | 22493.27 | 2.849 | 10.331 | 127.82 | 5.55 | 0 |
+| `prefix-after-regex` | base | `/prefix/health` | 23162.59 | 0.594 | 6.245 | 173.15 | 5.56 | 0 |
+| `prefix-after-regex` | head | `/prefix/health` | 24765.01 | 0.749 | 7.731 | 144.61 | 5.48 | 0 |
+
+These two rows exercise the runtime matcher branch changed by this audit. The
+`regex-match` path returns from the regex location. The `prefix-after-regex`
+path evaluates a non-matching regex first, then returns the borrowed plain
+prefix location. CPU is the benchmark runner's short macOS PID sample, so it is
+recorded as local fallback evidence rather than a canonical release baseline.
 
 Large streaming proxy server config:
 
@@ -137,7 +211,9 @@ is not used as quantitative evidence.
 | Proxy target URL and optional query string | Request-owned | Freed before proxy dispatch helper completion, or by the request path before retry/keepalive state is released | Direct allocation is retained. These strings may be needed across retry/error handling for a single request but must not be retained by upstream connection pools. |
 | Forwarded request header vector | Worker/request scratch | `stackFallback` storage is released when header assembly returns; heap fallback is freed by `ArrayList.deinit` | Existing bounded stack fallback is the right reuse mechanism. The warm proxy scenario confirms forwarded headers remain stack-backed. |
 | Proxy trusted-identity derived header values | Request-owned | Freed with the request's owned header value list after upstream dispatch completes | Direct allocation is retained because values include per-request timestamp/signature material and cannot be shared with connection-owned pools. |
-| Mixed route selection and server/location matching | Process/config-owned metadata plus request-owned regex scratch | Matching returns before dispatch; matched route slices remain tied to the config snapshot, while regex pattern/input scratch is freed before match return | Direct request-allocator scratch is retained for regex routes. The `mixed-route-selection` harness row records 8 allocations/356 bytes per request for the representative exact, prefix-priority, regex, and prefix sequence. POSIX `regcomp` remains an external libc allocation boundary; precompiled config-owned regexes are a future targeted optimization if regex-heavy routing becomes material. |
+| Exact and priority-prefix server/location matching | Process/config-owned metadata plus borrowed request URI path | Matching returns before dispatch; matched route slices remain tied to the config snapshot | No request workspace is needed. The `mixed-route-exact` and `mixed-route-priority` rows enforce zero request-allocator churn for the request classes that return before regex evaluation. |
+| H1 regex server/location matching | Process/config-owned metadata plus request-arena regex scratch | Logical regex scratch frees occur before match return, but the H1 request arena retains backing capacity until `handleConnection` request-arena deinit | Direct request-arena scratch is retained. The `mixed-route-regex` and `mixed-route-prefix-after-regex` rows record logical scratch churn for one matcher invocation/request class; `h1-regex-route-arena-reset` models two route resolutions in one H1 request and proves backing storage returns to zero live bytes only after request completion. POSIX `regcomp` remains an external libc allocation boundary; precompiled config-owned regexes are a future targeted optimization if regex-heavy routing becomes material. |
+| H2/H3 regex server/location matching | Allocator supplied by the H2/H3 dispatch path plus process/config-owned metadata | Reset follows the supplied allocator's owner, not the route matcher call itself | The matcher is allocator-aware, so H2/H3 callers account scratch against their dispatch allocator. They must not assume a universal match-scoped physical release boundary. |
 | Buffered proxy response body | Request-owned, with aggregate proxy-buffer accounting | Released after downstream write completion, abort cleanup, or local capacity failure handling | Existing accounting and streaming fallback rules are the safety mechanism. Reusing this memory in a request arena would risk hiding retained bytes from proxy buffer limits. |
 | HTTP/1 streaming relay buffer and response-head arena | Request/proxy-attempt-owned | Released when `streamProxyOverTransport` returns after body relay, abort cleanup, or local capacity failure handling | A request workspace must not reset at response-head generation because the relay buffer and parsed head arena live through the full streaming attempt. They may reset after the attempt completes. |
 | HTTP/2 stream receive queues and connection backpressure state | Stream/connection-owned | Queue drain, stream close/reset, connection close, or pool teardown | Never point these structures into request-reset memory. They can outlive a request-local header-generation phase and are independently accounted. |
@@ -182,6 +258,7 @@ mechanisms match the actual owners:
   strings.
 
 The benchmark additions in `src/allocation_regression.zig` make header-heavy
-proxy response metadata ownership and mixed route selection explicit. Any future
-workspace or pool should be added only when a measured scenario shows material
-allocator churn and the owner has a single reset boundary.
+proxy response metadata ownership, per-request route matcher classes, and the
+H1 request-arena reset boundary explicit. Any future workspace or pool should
+be added only when a measured scenario shows material allocator churn and the
+owner has a single reset boundary.

--- a/src/allocation_regression.zig
+++ b/src/allocation_regression.zig
@@ -17,6 +17,7 @@ const Scenario = enum {
     static_304_conditional,
     proxy_keepalive_warm,
     proxy_header_heavy_response,
+    mixed_route_selection,
     rejected_overload,
 
     fn name(self: Scenario) []const u8 {
@@ -25,6 +26,7 @@ const Scenario = enum {
             .static_304_conditional => "static-304-conditional",
             .proxy_keepalive_warm => "proxy-keepalive-warm",
             .proxy_header_heavy_response => "proxy-header-heavy-response",
+            .mixed_route_selection => "mixed-route-selection",
             .rejected_overload => "rejected-overload",
         };
     }
@@ -53,14 +55,22 @@ const Scenario = enum {
                 .max_bytes_per_request = 512,
                 .rationale = "warm keepalive proxy helper work owns resolved target strings; forwarded headers remain stack-backed",
             },
-            // Header-heavy streamed responses intentionally borrow parsed
-            // upstream header slices and format the downstream response head
-            // into caller-owned output. Retaining these slices past response
-            // serialization would be a lifetime bug, not a pooling target.
+            // Header-heavy buffered responses allocate filtered upstream
+            // metadata in the same arena-backed production parser used by the
+            // proxy path; response serialization then writes through
+            // caller-owned output.
             .proxy_header_heavy_response => .{
+                .max_allocations_per_request = 16,
+                .max_bytes_per_request = 2048,
+                .rationale = "header-heavy buffered proxy response parsing owns filtered metadata in an arena; serialization writes through caller-owned buffers",
+            },
+            // Location matching reads process/config-owned route metadata and
+            // returns borrowed slices. A request workspace would be the wrong
+            // owner for these references.
+            .mixed_route_selection => .{
                 .max_allocations_per_request = 0,
                 .max_bytes_per_request = 0,
-                .rationale = "header-heavy proxy response rewrite borrows upstream header slices and writes through caller-owned buffers",
+                .rationale = "mixed route selection borrows immutable config-owned location blocks and allocates no request memory",
             },
             // Rejections are not the steady-state success path; JSON payload and
             // response headers are intentionally allocated for clear client errors.
@@ -229,7 +239,7 @@ pub fn main() !void {
     try stdout.flush();
 }
 
-fn collectResults(allocator: std.mem.Allocator, requests: usize) ![5]ScenarioResult {
+fn collectResults(allocator: std.mem.Allocator, requests: usize) ![6]ScenarioResult {
     var fixture = try StaticFixture.init(allocator);
     defer fixture.deinit(allocator);
 
@@ -243,6 +253,7 @@ fn collectResults(allocator: std.mem.Allocator, requests: usize) ![5]ScenarioRes
         try measureScenario(allocator, requests, .static_304_conditional, &fixture),
         try measureScenario(allocator, requests, .proxy_keepalive_warm, &fixture),
         try measureScenario(allocator, requests, .proxy_header_heavy_response, &fixture),
+        try measureScenario(allocator, requests, .mixed_route_selection, &fixture),
         try measureScenario(allocator, requests, .rejected_overload, &fixture),
     };
 }
@@ -256,7 +267,8 @@ fn measureScenario(allocator: std.mem.Allocator, requests: usize, scenario: Scen
             .static_tiny_file_warm => try runStaticTiny(fixture, measured_allocator),
             .static_304_conditional => try runStaticNotModified(fixture, measured_allocator),
             .proxy_keepalive_warm => try runProxyKeepaliveWarm(measured_allocator),
-            .proxy_header_heavy_response => try runProxyHeaderHeavyResponse(),
+            .proxy_header_heavy_response => try runProxyHeaderHeavyResponse(measured_allocator),
+            .mixed_route_selection => try runMixedRouteSelection(),
             .rejected_overload => try runRejectedOverload(measured_allocator),
         }
     }
@@ -327,22 +339,100 @@ fn runProxyKeepaliveWarm(allocator: std.mem.Allocator) !void {
     if (extra_headers.items.len != 4) return error.ProxyKeepaliveHeaderAssemblyFailed;
 }
 
-fn runProxyHeaderHeavyResponse() !void {
-    const upstream_headers = [_]std.http.Header{
-        .{ .name = "Content-Type", .value = "application/json" },
-        .{ .name = "Cache-Control", .value = "private, max-age=60" },
-        .{ .name = "ETag", .value = "\"allocation-regression-143\"" },
-        .{ .name = "X-App-Version", .value = "2026.08.21" },
-        .{ .name = "X-Trace-Region", .value = "iad" },
-        .{ .name = "Connection", .value = "keep-alive" },
-        .{ .name = "Server", .value = "origin-test" },
-        .{ .name = "X-Powered-By", .value = "origin-framework" },
-        .{ .name = "Set-Cookie", .value = "sid=abc; HttpOnly; SameSite=Lax" },
-        .{ .name = "Vary", .value = "Accept-Encoding" },
-    };
+fn runProxyHeaderHeavyResponse(allocator: std.mem.Allocator) !void {
+    var parsed = try gp.parseBufferedUpstreamResponse(allocator, "HTTP/1.1 200 OK\r\n" ++
+        "Content-Type: application/json\r\n" ++
+        "Cache-Control: private, max-age=60\r\n" ++
+        "ETag: \"allocation-regression-143\"\r\n" ++
+        "X-App-Version: 2026.08.21\r\n" ++
+        "X-Trace-Region: iad\r\n" ++
+        "Connection: keep-alive\r\n" ++
+        "Server: origin-test\r\n" ++
+        "X-Powered-By: origin-framework\r\n" ++
+        "Set-Cookie: sid=abc; HttpOnly; SameSite=Lax\r\n" ++
+        "Vary: Accept-Encoding\r\n" ++
+        "\r\n" ++
+        "{\"ok\":true}\n");
+    defer parsed.deinit(allocator);
+    if (parsed.headerValue("Connection") != null) return error.ProxyHeaderHeavyLeakedHopByHopHeader;
+    if (parsed.headerValue("Server") != null) return error.ProxyHeaderHeavyLeakedDisclosureHeader;
+    if (parsed.headerValue("X-Powered-By") != null) return error.ProxyHeaderHeavyLeakedDisclosureHeader;
 
     const security = http.security_headers.SecurityHeaders.default;
     var buf: [4096]u8 = undefined;
+    var stream = compat.fixedBufferStream(&buf);
+    try gpr.writeBufferedUpstreamResponse(
+        stream.writer(),
+        parsed,
+        true,
+        "tg-1778460305668-bfebecb410803023",
+        &security,
+        null,
+        "tg_sticky=proxy; Path=/; HttpOnly",
+    );
+    const out = stream.getWritten();
+    if (std.mem.find(u8, out, "X-App-Version: 2026.08.21\r\n") == null) return error.ProxyHeaderHeavyMissingForwardedHeader;
+    if (std.mem.find(u8, out, "X-Powered-By: origin-framework\r\n") != null) return error.ProxyHeaderHeavyLeakedDisclosureHeader;
+    if (std.mem.find(u8, out, "Set-Cookie: tg_sticky=proxy; Path=/; HttpOnly\r\n") == null) return error.ProxyHeaderHeavyMissingStickyCookie;
+    if (std.mem.find(u8, out, "{\"ok\":true}\n") == null) return error.ProxyHeaderHeavyMissingBody;
+}
+
+fn runMixedRouteSelection() !void {
+    const blocks = [_]http.location_router.LocationBlock{
+        .{
+            .match_type = .prefix,
+            .pattern = "/",
+            .priority = 10,
+            .action = .{ .static_root = .{ .root = "/srv/www", .alias = false, .autoindex = false, .index = "index.html", .try_files = "$uri" } },
+        },
+        .{
+            .match_type = .prefix,
+            .pattern = "/api/",
+            .priority = 4,
+            .action = .{ .proxy_pass = "http://127.0.0.1:3000" },
+        },
+        .{
+            .match_type = .prefix_priority,
+            .pattern = "/api/private/",
+            .priority = 1,
+            .action = .{ .return_response = .{ .status = 403, .body = "forbidden" } },
+        },
+        .{
+            .match_type = .exact,
+            .pattern = "/status/metrics",
+            .priority = 0,
+            .action = .{ .return_response = .{ .status = 200, .body = "metrics" } },
+        },
+        .{
+            .match_type = .regex,
+            .pattern = "^/assets/.+\\.css$",
+            .priority = 8,
+            .action = .{ .static_root = .{ .root = "/srv/assets", .alias = false, .autoindex = false, .index = "", .try_files = "$uri" } },
+        },
+    };
+
+    const exact = http.location_router.matchLocation("/status/metrics?format=prom", &blocks) orelse return error.MixedRouteSelectionMissedExact;
+    if (exact.index != 3) return error.MixedRouteSelectionWrongExact;
+
+    const priority = http.location_router.matchLocation("/api/private/users", &blocks) orelse return error.MixedRouteSelectionMissedPriority;
+    if (priority.index != 2) return error.MixedRouteSelectionWrongPriority;
+
+    const regex = http.location_router.matchLocation("/assets/site.css?v=1", &blocks) orelse return error.MixedRouteSelectionMissedRegex;
+    if (regex.index != 4) return error.MixedRouteSelectionWrongRegex;
+
+    const prefix = http.location_router.matchLocation("/api/users", &blocks) orelse return error.MixedRouteSelectionMissedPrefix;
+    if (prefix.index != 1) return error.MixedRouteSelectionWrongPrefix;
+}
+
+fn runProxyStreamedHeaderSerializer() !void {
+    const upstream_headers = [_]std.http.Header{
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Connection", .value = "keep-alive" },
+        .{ .name = "X-App-Version", .value = "2026.08.21" },
+    };
+
+    const security = http.security_headers.SecurityHeaders.default;
+    var buf: [2048]u8 = undefined;
     var stream = compat.fixedBufferStream(&buf);
     try gpr.writeStreamedUpstreamResponseHeadFromHeaders(
         stream.writer(),
@@ -358,8 +448,6 @@ fn runProxyHeaderHeavyResponse() !void {
     const out = stream.getWritten();
     if (std.mem.find(u8, out, "X-App-Version: 2026.08.21\r\n") == null) return error.ProxyHeaderHeavyMissingForwardedHeader;
     if (std.mem.find(u8, out, "Connection: keep-alive\r\n") != null) return error.ProxyHeaderHeavyLeakedHopByHopHeader;
-    if (std.mem.find(u8, out, "X-Powered-By: origin-framework\r\n") != null) return error.ProxyHeaderHeavyLeakedDisclosureHeader;
-    if (std.mem.find(u8, out, "Set-Cookie: tg_sticky=proxy; Path=/; HttpOnly\r\n") == null) return error.ProxyHeaderHeavyMissingStickyCookie;
 }
 
 fn runRejectedOverload(allocator: std.mem.Allocator) !void {
@@ -465,4 +553,9 @@ test "allocation benchmark report exposes per-request counters" {
     try std.testing.expect(std.mem.find(u8, out, "\"static-tiny-file-warm\"") != null);
     try std.testing.expect(std.mem.find(u8, out, "\"proxy-keepalive-warm\"") != null);
     try std.testing.expect(std.mem.find(u8, out, "\"proxy-header-heavy-response\"") != null);
+    try std.testing.expect(std.mem.find(u8, out, "\"mixed-route-selection\"") != null);
+}
+
+test "streamed proxy response header serializer filters borrowed headers without allocation" {
+    try runProxyStreamedHeaderSerializer();
 }

--- a/src/allocation_regression.zig
+++ b/src/allocation_regression.zig
@@ -89,11 +89,15 @@ const Scenario = enum {
             // allocation boundary; POSIX regcomp may still allocate internally
             // through libc.
             .mixed_route_regex,
-            .mixed_route_prefix_after_regex,
             => .{
                 .max_allocations_per_request = 12,
                 .max_bytes_per_request = 1024,
                 .rationale = "route selection borrows config-owned locations; regex scratch is request-allocator-owned while libc regcomp remains external",
+            },
+            .mixed_route_prefix_after_regex => .{
+                .max_allocations_per_request = 0,
+                .max_bytes_per_request = 0,
+                .rationale = "plain-prefix route selection after an anchored literal regex miss skips regex scratch and returns borrowed config-owned locations",
             },
             .h1_regex_route_arena_reset => .{
                 .max_allocations_per_request = 4,

--- a/src/allocation_regression.zig
+++ b/src/allocation_regression.zig
@@ -5,6 +5,7 @@ const gp = @import("gateway_proxy.zig");
 const gpr = @import("gateway_proxy_response.zig");
 
 const default_requests: usize = 32;
+const scenario_count = 10;
 
 const Budget = struct {
     max_allocations_per_request: usize,
@@ -17,7 +18,11 @@ const Scenario = enum {
     static_304_conditional,
     proxy_keepalive_warm,
     proxy_header_heavy_response,
-    mixed_route_selection,
+    mixed_route_exact,
+    mixed_route_priority,
+    mixed_route_regex,
+    mixed_route_prefix_after_regex,
+    h1_regex_route_arena_reset,
     rejected_overload,
 
     fn name(self: Scenario) []const u8 {
@@ -26,7 +31,11 @@ const Scenario = enum {
             .static_304_conditional => "static-304-conditional",
             .proxy_keepalive_warm => "proxy-keepalive-warm",
             .proxy_header_heavy_response => "proxy-header-heavy-response",
-            .mixed_route_selection => "mixed-route-selection",
+            .mixed_route_exact => "mixed-route-exact",
+            .mixed_route_priority => "mixed-route-priority",
+            .mixed_route_regex => "mixed-route-regex",
+            .mixed_route_prefix_after_regex => "mixed-route-prefix-after-regex",
+            .h1_regex_route_arena_reset => "h1-regex-route-arena-reset",
             .rejected_overload => "rejected-overload",
         };
     }
@@ -64,15 +73,32 @@ const Scenario = enum {
                 .max_bytes_per_request = 2048,
                 .rationale = "header-heavy buffered proxy response parsing owns filtered metadata in an arena; serialization writes through caller-owned buffers",
             },
-            // Location matching reads process/config-owned route metadata and
-            // returns borrowed route slices. Regex matching now routes Zig
-            // scratch through the request allocator so this budget can observe
-            // the allocation boundary; POSIX regcomp may still allocate
-            // internally through libc.
-            .mixed_route_selection => .{
+            .mixed_route_exact => .{
+                .max_allocations_per_request = 0,
+                .max_bytes_per_request = 0,
+                .rationale = "exact route selection borrows config-owned location blocks and returns before regex evaluation",
+            },
+            .mixed_route_priority => .{
+                .max_allocations_per_request = 0,
+                .max_bytes_per_request = 0,
+                .rationale = "priority-prefix route selection borrows config-owned location blocks and returns before regex evaluation",
+            },
+            // Regex route matching reads process/config-owned route metadata and
+            // returns borrowed route slices. Regex matching routes Zig scratch
+            // through the request allocator so this budget can observe the
+            // allocation boundary; POSIX regcomp may still allocate internally
+            // through libc.
+            .mixed_route_regex,
+            .mixed_route_prefix_after_regex,
+            => .{
                 .max_allocations_per_request = 12,
                 .max_bytes_per_request = 1024,
-                .rationale = "mixed route selection borrows config-owned locations; regex scratch is request-allocator-owned while libc regcomp remains external",
+                .rationale = "route selection borrows config-owned locations; regex scratch is request-allocator-owned while libc regcomp remains external",
+            },
+            .h1_regex_route_arena_reset => .{
+                .max_allocations_per_request = 4,
+                .max_bytes_per_request = 4096,
+                .rationale = "production-shaped H1 regex route scratch is retained by the request arena until request completion, then arena deinit releases backing storage",
             },
             // Rejections are not the steady-state success path; JSON payload and
             // response headers are intentionally allocated for clear client errors.
@@ -159,6 +185,39 @@ const CountingAllocator = struct {
     };
 };
 
+const mixed_route_blocks = [_]http.location_router.LocationBlock{
+    .{
+        .match_type = .prefix,
+        .pattern = "/",
+        .priority = 10,
+        .action = .{ .static_root = .{ .root = "/srv/www", .alias = false, .autoindex = false, .index = "index.html", .try_files = "$uri" } },
+    },
+    .{
+        .match_type = .prefix,
+        .pattern = "/api/",
+        .priority = 4,
+        .action = .{ .proxy_pass = "http://127.0.0.1:3000" },
+    },
+    .{
+        .match_type = .prefix_priority,
+        .pattern = "/api/private/",
+        .priority = 1,
+        .action = .{ .return_response = .{ .status = 403, .body = "forbidden" } },
+    },
+    .{
+        .match_type = .exact,
+        .pattern = "/status/metrics",
+        .priority = 0,
+        .action = .{ .return_response = .{ .status = 200, .body = "metrics" } },
+    },
+    .{
+        .match_type = .regex,
+        .pattern = "^/assets/.+\\.css$",
+        .priority = 8,
+        .action = .{ .static_root = .{ .root = "/srv/assets", .alias = false, .autoindex = false, .index = "", .try_files = "$uri" } },
+    },
+};
+
 const ScenarioResult = struct {
     scenario: Scenario,
     requests: usize,
@@ -241,7 +300,7 @@ pub fn main() !void {
     try stdout.flush();
 }
 
-fn collectResults(allocator: std.mem.Allocator, requests: usize) ![6]ScenarioResult {
+fn collectResults(allocator: std.mem.Allocator, requests: usize) ![scenario_count]ScenarioResult {
     var fixture = try StaticFixture.init(allocator);
     defer fixture.deinit(allocator);
 
@@ -255,7 +314,11 @@ fn collectResults(allocator: std.mem.Allocator, requests: usize) ![6]ScenarioRes
         try measureScenario(allocator, requests, .static_304_conditional, &fixture),
         try measureScenario(allocator, requests, .proxy_keepalive_warm, &fixture),
         try measureScenario(allocator, requests, .proxy_header_heavy_response, &fixture),
-        try measureScenario(allocator, requests, .mixed_route_selection, &fixture),
+        try measureScenario(allocator, requests, .mixed_route_exact, &fixture),
+        try measureScenario(allocator, requests, .mixed_route_priority, &fixture),
+        try measureScenario(allocator, requests, .mixed_route_regex, &fixture),
+        try measureScenario(allocator, requests, .mixed_route_prefix_after_regex, &fixture),
+        try measureScenario(allocator, requests, .h1_regex_route_arena_reset, &fixture),
         try measureScenario(allocator, requests, .rejected_overload, &fixture),
     };
 }
@@ -270,7 +333,11 @@ fn measureScenario(allocator: std.mem.Allocator, requests: usize, scenario: Scen
             .static_304_conditional => try runStaticNotModified(fixture, measured_allocator),
             .proxy_keepalive_warm => try runProxyKeepaliveWarm(measured_allocator),
             .proxy_header_heavy_response => try runProxyHeaderHeavyResponse(measured_allocator),
-            .mixed_route_selection => try runMixedRouteSelection(measured_allocator),
+            .mixed_route_exact => try runRouteRequest(measured_allocator, "/status/metrics?format=prom", 3),
+            .mixed_route_priority => try runRouteRequest(measured_allocator, "/api/private/users", 2),
+            .mixed_route_regex => try runRouteRequest(measured_allocator, "/assets/site.css?v=1", 4),
+            .mixed_route_prefix_after_regex => try runRouteRequest(measured_allocator, "/api/users", 1),
+            .h1_regex_route_arena_reset => try runH1RegexRouteArenaReset(measured_allocator),
             .rejected_overload => try runRejectedOverload(measured_allocator),
         }
     }
@@ -379,51 +446,25 @@ fn runProxyHeaderHeavyResponse(allocator: std.mem.Allocator) !void {
     if (std.mem.find(u8, out, "{\"ok\":true}\n") == null) return error.ProxyHeaderHeavyMissingBody;
 }
 
-fn runMixedRouteSelection(allocator: std.mem.Allocator) !void {
-    const blocks = [_]http.location_router.LocationBlock{
-        .{
-            .match_type = .prefix,
-            .pattern = "/",
-            .priority = 10,
-            .action = .{ .static_root = .{ .root = "/srv/www", .alias = false, .autoindex = false, .index = "index.html", .try_files = "$uri" } },
-        },
-        .{
-            .match_type = .prefix,
-            .pattern = "/api/",
-            .priority = 4,
-            .action = .{ .proxy_pass = "http://127.0.0.1:3000" },
-        },
-        .{
-            .match_type = .prefix_priority,
-            .pattern = "/api/private/",
-            .priority = 1,
-            .action = .{ .return_response = .{ .status = 403, .body = "forbidden" } },
-        },
-        .{
-            .match_type = .exact,
-            .pattern = "/status/metrics",
-            .priority = 0,
-            .action = .{ .return_response = .{ .status = 200, .body = "metrics" } },
-        },
-        .{
-            .match_type = .regex,
-            .pattern = "^/assets/.+\\.css$",
-            .priority = 8,
-            .action = .{ .static_root = .{ .root = "/srv/assets", .alias = false, .autoindex = false, .index = "", .try_files = "$uri" } },
-        },
-    };
+fn runRouteRequest(allocator: std.mem.Allocator, path: []const u8, expected_index: usize) !void {
+    const matched = http.location_router.matchLocation(allocator, path, &mixed_route_blocks) orelse return error.MixedRouteSelectionMiss;
+    if (matched.index != expected_index) return error.MixedRouteSelectionWrongRoute;
+}
 
-    const exact = http.location_router.matchLocation(allocator, "/status/metrics?format=prom", &blocks) orelse return error.MixedRouteSelectionMissedExact;
-    if (exact.index != 3) return error.MixedRouteSelectionWrongExact;
+fn runH1RegexRouteArenaReset(backing_allocator: std.mem.Allocator) !void {
+    var counter = CountingAllocator.init(backing_allocator);
+    {
+        var arena_state = std.heap.ArenaAllocator.init(counter.allocator());
+        defer arena_state.deinit();
+        const request_allocator = arena_state.allocator();
 
-    const priority = http.location_router.matchLocation(allocator, "/api/private/users", &blocks) orelse return error.MixedRouteSelectionMissedPriority;
-    if (priority.index != 2) return error.MixedRouteSelectionWrongPriority;
-
-    const regex = http.location_router.matchLocation(allocator, "/assets/site.css?v=1", &blocks) orelse return error.MixedRouteSelectionMissedRegex;
-    if (regex.index != 4) return error.MixedRouteSelectionWrongRegex;
-
-    const prefix = http.location_router.matchLocation(allocator, "/api/users", &blocks) orelse return error.MixedRouteSelectionMissedPrefix;
-    if (prefix.index != 1) return error.MixedRouteSelectionWrongPrefix;
+        // Production H1 can route-match before body handling and again at
+        // dispatch. The arena retains backing capacity until request teardown.
+        try runRouteRequest(request_allocator, "/assets/site.css?v=1", 4);
+        try runRouteRequest(request_allocator, "/assets/site.css?v=1", 4);
+        if (counter.stats.peak_live_bytes == 0) return error.H1RegexArenaDidNotAllocate;
+    }
+    if (counter.stats.live_bytes != 0) return error.H1RegexArenaLeaked;
 }
 
 fn runProxyStreamedHeaderSerializer() !void {
@@ -555,7 +596,8 @@ test "allocation benchmark report exposes per-request counters" {
     try std.testing.expect(std.mem.find(u8, out, "\"static-tiny-file-warm\"") != null);
     try std.testing.expect(std.mem.find(u8, out, "\"proxy-keepalive-warm\"") != null);
     try std.testing.expect(std.mem.find(u8, out, "\"proxy-header-heavy-response\"") != null);
-    try std.testing.expect(std.mem.find(u8, out, "\"mixed-route-selection\"") != null);
+    try std.testing.expect(std.mem.find(u8, out, "\"mixed-route-regex\"") != null);
+    try std.testing.expect(std.mem.find(u8, out, "\"h1-regex-route-arena-reset\"") != null);
 }
 
 test "streamed proxy response header serializer filters borrowed headers without allocation" {

--- a/src/allocation_regression.zig
+++ b/src/allocation_regression.zig
@@ -65,12 +65,14 @@ const Scenario = enum {
                 .rationale = "header-heavy buffered proxy response parsing owns filtered metadata in an arena; serialization writes through caller-owned buffers",
             },
             // Location matching reads process/config-owned route metadata and
-            // returns borrowed slices. A request workspace would be the wrong
-            // owner for these references.
+            // returns borrowed route slices. Regex matching now routes Zig
+            // scratch through the request allocator so this budget can observe
+            // the allocation boundary; POSIX regcomp may still allocate
+            // internally through libc.
             .mixed_route_selection => .{
-                .max_allocations_per_request = 0,
-                .max_bytes_per_request = 0,
-                .rationale = "mixed route selection borrows immutable config-owned location blocks and allocates no request memory",
+                .max_allocations_per_request = 12,
+                .max_bytes_per_request = 1024,
+                .rationale = "mixed route selection borrows config-owned locations; regex scratch is request-allocator-owned while libc regcomp remains external",
             },
             // Rejections are not the steady-state success path; JSON payload and
             // response headers are intentionally allocated for clear client errors.
@@ -268,7 +270,7 @@ fn measureScenario(allocator: std.mem.Allocator, requests: usize, scenario: Scen
             .static_304_conditional => try runStaticNotModified(fixture, measured_allocator),
             .proxy_keepalive_warm => try runProxyKeepaliveWarm(measured_allocator),
             .proxy_header_heavy_response => try runProxyHeaderHeavyResponse(measured_allocator),
-            .mixed_route_selection => try runMixedRouteSelection(),
+            .mixed_route_selection => try runMixedRouteSelection(measured_allocator),
             .rejected_overload => try runRejectedOverload(measured_allocator),
         }
     }
@@ -377,7 +379,7 @@ fn runProxyHeaderHeavyResponse(allocator: std.mem.Allocator) !void {
     if (std.mem.find(u8, out, "{\"ok\":true}\n") == null) return error.ProxyHeaderHeavyMissingBody;
 }
 
-fn runMixedRouteSelection() !void {
+fn runMixedRouteSelection(allocator: std.mem.Allocator) !void {
     const blocks = [_]http.location_router.LocationBlock{
         .{
             .match_type = .prefix,
@@ -411,16 +413,16 @@ fn runMixedRouteSelection() !void {
         },
     };
 
-    const exact = http.location_router.matchLocation("/status/metrics?format=prom", &blocks) orelse return error.MixedRouteSelectionMissedExact;
+    const exact = http.location_router.matchLocation(allocator, "/status/metrics?format=prom", &blocks) orelse return error.MixedRouteSelectionMissedExact;
     if (exact.index != 3) return error.MixedRouteSelectionWrongExact;
 
-    const priority = http.location_router.matchLocation("/api/private/users", &blocks) orelse return error.MixedRouteSelectionMissedPriority;
+    const priority = http.location_router.matchLocation(allocator, "/api/private/users", &blocks) orelse return error.MixedRouteSelectionMissedPriority;
     if (priority.index != 2) return error.MixedRouteSelectionWrongPriority;
 
-    const regex = http.location_router.matchLocation("/assets/site.css?v=1", &blocks) orelse return error.MixedRouteSelectionMissedRegex;
+    const regex = http.location_router.matchLocation(allocator, "/assets/site.css?v=1", &blocks) orelse return error.MixedRouteSelectionMissedRegex;
     if (regex.index != 4) return error.MixedRouteSelectionWrongRegex;
 
-    const prefix = http.location_router.matchLocation("/api/users", &blocks) orelse return error.MixedRouteSelectionMissedPrefix;
+    const prefix = http.location_router.matchLocation(allocator, "/api/users", &blocks) orelse return error.MixedRouteSelectionMissedPrefix;
     if (prefix.index != 1) return error.MixedRouteSelectionWrongPrefix;
 }
 

--- a/src/allocation_regression.zig
+++ b/src/allocation_regression.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const compat = @import("zig_compat");
 const http = @import("http.zig");
 const gp = @import("gateway_proxy.zig");
+const gpr = @import("gateway_proxy_response.zig");
 
 const default_requests: usize = 32;
 
@@ -15,6 +16,7 @@ const Scenario = enum {
     static_tiny_file_warm,
     static_304_conditional,
     proxy_keepalive_warm,
+    proxy_header_heavy_response,
     rejected_overload,
 
     fn name(self: Scenario) []const u8 {
@@ -22,6 +24,7 @@ const Scenario = enum {
             .static_tiny_file_warm => "static-tiny-file-warm",
             .static_304_conditional => "static-304-conditional",
             .proxy_keepalive_warm => "proxy-keepalive-warm",
+            .proxy_header_heavy_response => "proxy-header-heavy-response",
             .rejected_overload => "rejected-overload",
         };
     }
@@ -49,6 +52,15 @@ const Scenario = enum {
                 .max_allocations_per_request = 6,
                 .max_bytes_per_request = 512,
                 .rationale = "warm keepalive proxy helper work owns resolved target strings; forwarded headers remain stack-backed",
+            },
+            // Header-heavy streamed responses intentionally borrow parsed
+            // upstream header slices and format the downstream response head
+            // into caller-owned output. Retaining these slices past response
+            // serialization would be a lifetime bug, not a pooling target.
+            .proxy_header_heavy_response => .{
+                .max_allocations_per_request = 0,
+                .max_bytes_per_request = 0,
+                .rationale = "header-heavy proxy response rewrite borrows upstream header slices and writes through caller-owned buffers",
             },
             // Rejections are not the steady-state success path; JSON payload and
             // response headers are intentionally allocated for clear client errors.
@@ -217,7 +229,7 @@ pub fn main() !void {
     try stdout.flush();
 }
 
-fn collectResults(allocator: std.mem.Allocator, requests: usize) ![4]ScenarioResult {
+fn collectResults(allocator: std.mem.Allocator, requests: usize) ![5]ScenarioResult {
     var fixture = try StaticFixture.init(allocator);
     defer fixture.deinit(allocator);
 
@@ -230,6 +242,7 @@ fn collectResults(allocator: std.mem.Allocator, requests: usize) ![4]ScenarioRes
         try measureScenario(allocator, requests, .static_tiny_file_warm, &fixture),
         try measureScenario(allocator, requests, .static_304_conditional, &fixture),
         try measureScenario(allocator, requests, .proxy_keepalive_warm, &fixture),
+        try measureScenario(allocator, requests, .proxy_header_heavy_response, &fixture),
         try measureScenario(allocator, requests, .rejected_overload, &fixture),
     };
 }
@@ -243,6 +256,7 @@ fn measureScenario(allocator: std.mem.Allocator, requests: usize, scenario: Scen
             .static_tiny_file_warm => try runStaticTiny(fixture, measured_allocator),
             .static_304_conditional => try runStaticNotModified(fixture, measured_allocator),
             .proxy_keepalive_warm => try runProxyKeepaliveWarm(measured_allocator),
+            .proxy_header_heavy_response => try runProxyHeaderHeavyResponse(),
             .rejected_overload => try runRejectedOverload(measured_allocator),
         }
     }
@@ -311,6 +325,41 @@ fn runProxyKeepaliveWarm(allocator: std.mem.Allocator) !void {
     if (query.owned != null) return error.ProxyKeepaliveQueryAllocated;
     if (forwarded.owned != null) return error.ProxyKeepaliveForwardedForAllocated;
     if (extra_headers.items.len != 4) return error.ProxyKeepaliveHeaderAssemblyFailed;
+}
+
+fn runProxyHeaderHeavyResponse() !void {
+    const upstream_headers = [_]std.http.Header{
+        .{ .name = "Content-Type", .value = "application/json" },
+        .{ .name = "Cache-Control", .value = "private, max-age=60" },
+        .{ .name = "ETag", .value = "\"allocation-regression-143\"" },
+        .{ .name = "X-App-Version", .value = "2026.08.21" },
+        .{ .name = "X-Trace-Region", .value = "iad" },
+        .{ .name = "Connection", .value = "keep-alive" },
+        .{ .name = "Server", .value = "origin-test" },
+        .{ .name = "X-Powered-By", .value = "origin-framework" },
+        .{ .name = "Set-Cookie", .value = "sid=abc; HttpOnly; SameSite=Lax" },
+        .{ .name = "Vary", .value = "Accept-Encoding" },
+    };
+
+    const security = http.security_headers.SecurityHeaders.default;
+    var buf: [4096]u8 = undefined;
+    var stream = compat.fixedBufferStream(&buf);
+    try gpr.writeStreamedUpstreamResponseHeadFromHeaders(
+        stream.writer(),
+        200,
+        "OK",
+        &upstream_headers,
+        true,
+        "tg-1778460305668-bfebecb410803023",
+        &security,
+        null,
+        "tg_sticky=proxy; Path=/; HttpOnly",
+    );
+    const out = stream.getWritten();
+    if (std.mem.find(u8, out, "X-App-Version: 2026.08.21\r\n") == null) return error.ProxyHeaderHeavyMissingForwardedHeader;
+    if (std.mem.find(u8, out, "Connection: keep-alive\r\n") != null) return error.ProxyHeaderHeavyLeakedHopByHopHeader;
+    if (std.mem.find(u8, out, "X-Powered-By: origin-framework\r\n") != null) return error.ProxyHeaderHeavyLeakedDisclosureHeader;
+    if (std.mem.find(u8, out, "Set-Cookie: tg_sticky=proxy; Path=/; HttpOnly\r\n") == null) return error.ProxyHeaderHeavyMissingStickyCookie;
 }
 
 fn runRejectedOverload(allocator: std.mem.Allocator) !void {
@@ -415,4 +464,5 @@ test "allocation benchmark report exposes per-request counters" {
     try std.testing.expect(std.mem.find(u8, out, "\"bytes_allocated_per_request\"") != null);
     try std.testing.expect(std.mem.find(u8, out, "\"static-tiny-file-warm\"") != null);
     try std.testing.expect(std.mem.find(u8, out, "\"proxy-keepalive-warm\"") != null);
+    try std.testing.expect(std.mem.find(u8, out, "\"proxy-header-heavy-response\"") != null);
 }

--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -3173,7 +3173,7 @@ fn executeHttp2ProxyRoute(
         return .{ .local_rejection = rejection };
     }
 
-    const matched = http.location_router.matchLocation(request.uri.path, route_cfg.location_blocks) orelse return null;
+    const matched = http.location_router.matchLocation(allocator, request.uri.path, route_cfg.location_blocks) orelse return null;
     if (matched.block.auth == .required) return .{ .local_rejection = .{
         .status_code = @intFromEnum(http.Status.unauthorized),
         .code = "unauthorized",
@@ -3561,12 +3561,13 @@ fn targetStreamingFallbackReason(
 }
 
 fn streamingUploadEligibilityBeforeBodyRead(
+    allocator: std.mem.Allocator,
     cfg: *const edge_config.EdgeConfig,
     request: *const http.Request,
 ) RequestUploadStreamingEligibility {
     if (!request.method.hasRequestBody()) return .not_applicable;
 
-    const matched = http.location_router.matchLocation(request.uri.path, cfg.location_blocks) orelse return .{ .fallback = .unsupported_route_type };
+    const matched = http.location_router.matchLocation(allocator, request.uri.path, cfg.location_blocks) orelse return .{ .fallback = .unsupported_route_type };
     if (!matched.block.proxy_streaming_policy.requestStreamingEnabled(cfg.proxy_streaming_mode.requestStreamingEnabled())) return .{ .fallback = .policy_disabled };
 
     if (cfg.rewrite_rules.len > 0 or cfg.return_rules.len > 0 or
@@ -3611,11 +3612,13 @@ fn traceRejectionStatus(
 }
 
 fn earlyDataPreflightDecisionForH1(
+    allocator: std.mem.Allocator,
     cfg: *const edge_config.EdgeConfig,
     early_ctx: http.request_context.EarlyDataContext,
     request: *const http.Request,
 ) http.early_data.Decision {
     return ghandlers.earlyDataDecisionForRequest(
+        allocator,
         cfg,
         early_ctx,
         request.method,
@@ -3751,7 +3754,7 @@ fn executeH1PostPreflightOrchestration(
         state.metricsRecordEarlyDataRequest(.h1, source);
     }
 
-    const early_decision = earlyDataPreflightDecisionForH1(cfg, ctx.early_data, request);
+    const early_decision = earlyDataPreflightDecisionForH1(allocator, cfg, ctx.early_data, request);
     switch (early_decision) {
         .ordinary => {
             ctx.early_data_action = .ordinary;
@@ -3921,7 +3924,7 @@ fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge
         };
         var pre_effective_cfg_storage = cfg.*;
         const pre_effective_cfg = ga.resolveRequestConfig(cfg, head_parse.request.headers.get("host"), &pre_effective_cfg_storage) orelse cfg;
-        const upload_eligibility = streamingUploadEligibilityBeforeBodyRead(pre_effective_cfg, &head_parse.request);
+        const upload_eligibility = streamingUploadEligibilityBeforeBodyRead(allocator, pre_effective_cfg, &head_parse.request);
         switch (upload_eligibility) {
             .stream => {
                 streaming_request_body = streamingRequestBodyFromHead(pre_effective_cfg, &head_parse.request, pending_buf, head_read, head_parse.bytes_consumed);
@@ -5136,7 +5139,7 @@ test "streaming upload eligibility reports typed fallback reasons" {
         MAX_REQUEST_SIZE,
     );
     defer upload_head.request.deinit();
-    try std.testing.expectEqual(RequestUploadStreamingEligibility.stream, streamingUploadEligibilityBeforeBodyRead(&cfg, &upload_head.request));
+    try std.testing.expectEqual(RequestUploadStreamingEligibility.stream, streamingUploadEligibilityBeforeBodyRead(std.testing.allocator, &cfg, &upload_head.request));
 
     var chunked_head = try http.Request.parseHead(
         allocator,
@@ -5145,7 +5148,7 @@ test "streaming upload eligibility reports typed fallback reasons" {
     );
     defer chunked_head.request.deinit();
     // A chunked upload is re-framed incrementally rather than buffered (#139).
-    try std.testing.expectEqual(RequestUploadStreamingEligibility.stream, streamingUploadEligibilityBeforeBodyRead(&cfg, &chunked_head.request));
+    try std.testing.expectEqual(RequestUploadStreamingEligibility.stream, streamingUploadEligibilityBeforeBodyRead(std.testing.allocator, &cfg, &chunked_head.request));
 
     var compat_head = try http.Request.parseHead(
         allocator,
@@ -5153,7 +5156,7 @@ test "streaming upload eligibility reports typed fallback reasons" {
         MAX_REQUEST_SIZE,
     );
     defer compat_head.request.deinit();
-    try std.testing.expectEqual(RequestUploadStreamingEligibility{ .fallback = .policy_disabled }, streamingUploadEligibilityBeforeBodyRead(&cfg, &compat_head.request));
+    try std.testing.expectEqual(RequestUploadStreamingEligibility{ .fallback = .policy_disabled }, streamingUploadEligibilityBeforeBodyRead(std.testing.allocator, &cfg, &compat_head.request));
 
     var compat_chunked_head = try http.Request.parseHead(
         allocator,
@@ -5161,10 +5164,10 @@ test "streaming upload eligibility reports typed fallback reasons" {
         MAX_REQUEST_SIZE,
     );
     defer compat_chunked_head.request.deinit();
-    try std.testing.expectEqual(RequestUploadStreamingEligibility{ .fallback = .policy_disabled }, streamingUploadEligibilityBeforeBodyRead(&cfg, &compat_chunked_head.request));
+    try std.testing.expectEqual(RequestUploadStreamingEligibility{ .fallback = .policy_disabled }, streamingUploadEligibilityBeforeBodyRead(std.testing.allocator, &cfg, &compat_chunked_head.request));
 
     cfg.auth_request_url = "http://auth.example.test/check";
-    try std.testing.expectEqual(RequestUploadStreamingEligibility{ .fallback = .body_dependent_middleware }, streamingUploadEligibilityBeforeBodyRead(&cfg, &upload_head.request));
+    try std.testing.expectEqual(RequestUploadStreamingEligibility{ .fallback = .body_dependent_middleware }, streamingUploadEligibilityBeforeBodyRead(std.testing.allocator, &cfg, &upload_head.request));
 }
 
 test "streaming upload pre-read scan includes server block routes" {

--- a/src/gateway_handlers.zig
+++ b/src/gateway_handlers.zig
@@ -59,8 +59,8 @@ pub const RouteDecision = union(enum) {
 /// fall-through and change behavior. So it stays a pre-check in `routeRequest`
 /// until that matcher is split from its handler. Fold it in with the pre-route
 /// middleware stage (later #201 PR).
-pub fn resolveRoute(cfg: *const edge_config.EdgeConfig, request: *const http.Request) RouteDecision {
-    return resolveRoutePath(cfg.metrics_path, cfg.location_blocks, request.uri.path);
+pub fn resolveRoute(allocator: std.mem.Allocator, cfg: *const edge_config.EdgeConfig, request: *const http.Request) RouteDecision {
+    return resolveRoutePath(allocator, cfg.metrics_path, cfg.location_blocks, request.uri.path);
 }
 
 /// Pure route-matching precedence — no I/O, no mutation of `state`/`request`.
@@ -70,13 +70,14 @@ pub fn resolveRoute(cfg: *const edge_config.EdgeConfig, request: *const http.Req
 /// Mirrors the order previously inlined in `routeRequest`: reload-status path,
 /// then the configured metrics path, then location blocks.
 pub fn resolveRoutePath(
+    allocator: std.mem.Allocator,
     metrics_path: []const u8,
     location_blocks: []const http.location_router.LocationBlock,
     path: []const u8,
 ) RouteDecision {
     if (std.mem.eql(u8, path, "/tardigrade/reload/status")) return .reload_status;
     if (metrics_path.len > 0 and std.mem.eql(u8, path, metrics_path)) return .metrics;
-    if (http.location_router.matchLocation(path, location_blocks)) |matched| {
+    if (http.location_router.matchLocation(allocator, path, location_blocks)) |matched| {
         return .{ .location = matched };
     }
     return .unmatched;
@@ -123,16 +124,18 @@ fn isTranscriptRoutePath(path: []const u8) bool {
 }
 
 pub fn earlyDataDecisionForRequest(
+    allocator: std.mem.Allocator,
     cfg: *const edge_config.EdgeConfig,
     early_ctx: http.request_context.EarlyDataContext,
     method: http.Method,
     path: []const u8,
     has_body_framing: bool,
 ) http.early_data.Decision {
-    return earlyDataDecisionForRawMethod(cfg, early_ctx, method.toString(), path, has_body_framing);
+    return earlyDataDecisionForRawMethod(allocator, cfg, early_ctx, method.toString(), path, has_body_framing);
 }
 
 pub fn earlyDataDecisionForRawMethod(
+    allocator: std.mem.Allocator,
     cfg: *const edge_config.EdgeConfig,
     early_ctx: http.request_context.EarlyDataContext,
     method: []const u8,
@@ -144,7 +147,7 @@ pub fn earlyDataDecisionForRawMethod(
     if (isTranscriptRoutePath(path)) return .too_early;
     if (hasMatchingMirrorRule(cfg.mirror_rules, method, path)) return .too_early;
 
-    return switch (resolveRoutePath(cfg.metrics_path, cfg.location_blocks, path)) {
+    return switch (resolveRoutePath(allocator, cfg.metrics_path, cfg.location_blocks, path)) {
         .reload_status, .metrics, .unmatched => .too_early,
         .location => |matched| locationEarlyDataDecision(early_ctx, http.early_data.methodSafe(method), matched.block),
     };
@@ -221,22 +224,22 @@ test "resolveRoutePath: reload-status and metrics precede location matching" {
     };
     const Tag = std.meta.Tag(RouteDecision);
     // reload-status wins over a configured metrics path and a catch-all location.
-    try std.testing.expectEqual(Tag.reload_status, std.meta.activeTag(resolveRoutePath("/metrics", &blocks, "/tardigrade/reload/status")));
+    try std.testing.expectEqual(Tag.reload_status, std.meta.activeTag(resolveRoutePath(std.testing.allocator, "/metrics", &blocks, "/tardigrade/reload/status")));
     // metrics path wins over a matching location.
-    try std.testing.expectEqual(Tag.metrics, std.meta.activeTag(resolveRoutePath("/metrics", &blocks, "/metrics")));
+    try std.testing.expectEqual(Tag.metrics, std.meta.activeTag(resolveRoutePath(std.testing.allocator, "/metrics", &blocks, "/metrics")));
     // an empty metrics_path disables the metrics route, falling to the location.
-    try std.testing.expectEqual(Tag.location, std.meta.activeTag(resolveRoutePath("", &blocks, "/metrics")));
+    try std.testing.expectEqual(Tag.location, std.meta.activeTag(resolveRoutePath(std.testing.allocator, "", &blocks, "/metrics")));
 }
 
 test "resolveRoutePath: location match carries the block, else unmatched" {
     const blocks = [_]http.location_router.LocationBlock{
         .{ .match_type = .exact, .pattern = "/app", .priority = 1, .action = .{ .proxy_pass = "" } },
     };
-    switch (resolveRoutePath("/status/metrics", &blocks, "/app")) {
+    switch (resolveRoutePath(std.testing.allocator, "/status/metrics", &blocks, "/app")) {
         .location => |m| try std.testing.expectEqualStrings("/app", m.block.pattern),
         else => try std.testing.expect(false),
     }
-    try std.testing.expectEqual(std.meta.Tag(RouteDecision).unmatched, std.meta.activeTag(resolveRoutePath("/status/metrics", &blocks, "/nope")));
+    try std.testing.expectEqual(std.meta.Tag(RouteDecision).unmatched, std.meta.activeTag(resolveRoutePath(std.testing.allocator, "/status/metrics", &blocks, "/nope")));
 }
 
 test "earlyDataDecisionForRequest gates H1 routes before side effects" {
@@ -283,19 +286,19 @@ test "earlyDataDecisionForRequest gates H1 routes before side effects" {
 
     const ordinary = http.request_context.EarlyDataContext{};
     const early = http.request_context.EarlyDataContext{ .transport_early = true };
-    try std.testing.expectEqual(http.early_data.Decision.ordinary, earlyDataDecisionForRequest(&cfg, ordinary, .GET, "/off", false));
-    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(&cfg, early, .GET, "/off", false));
-    try std.testing.expectEqual(http.early_data.Decision.execute_local, earlyDataDecisionForRequest(&cfg, early, .GET, "/safe", false));
-    try std.testing.expectEqual(http.early_data.Decision.execute_local, earlyDataDecisionForRequest(&cfg, early, .HEAD, "/safe", false));
-    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(&cfg, early, .GET, "/safe", true));
-    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(&cfg, early, .HEAD, "/safe", true));
-    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(&cfg, early, .POST, "/safe", false));
-    try std.testing.expectEqual(http.early_data.Decision.forward_rfc8470, earlyDataDecisionForRequest(&cfg, early, .GET, "/proxy", false));
-    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(&cfg, early, .GET, "/auth", false));
-    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(&cfg, early, .GET, "/rewrite", false));
-    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(&cfg, early, .GET, cfg.metrics_path, false));
-    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(&cfg, early, .GET, "/transcripts", false));
-    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(&cfg, early, .GET, "/missing", false));
+    try std.testing.expectEqual(http.early_data.Decision.ordinary, earlyDataDecisionForRequest(std.testing.allocator, &cfg, ordinary, .GET, "/off", false));
+    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(std.testing.allocator, &cfg, early, .GET, "/off", false));
+    try std.testing.expectEqual(http.early_data.Decision.execute_local, earlyDataDecisionForRequest(std.testing.allocator, &cfg, early, .GET, "/safe", false));
+    try std.testing.expectEqual(http.early_data.Decision.execute_local, earlyDataDecisionForRequest(std.testing.allocator, &cfg, early, .HEAD, "/safe", false));
+    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(std.testing.allocator, &cfg, early, .GET, "/safe", true));
+    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(std.testing.allocator, &cfg, early, .HEAD, "/safe", true));
+    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(std.testing.allocator, &cfg, early, .POST, "/safe", false));
+    try std.testing.expectEqual(http.early_data.Decision.forward_rfc8470, earlyDataDecisionForRequest(std.testing.allocator, &cfg, early, .GET, "/proxy", false));
+    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(std.testing.allocator, &cfg, early, .GET, "/auth", false));
+    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(std.testing.allocator, &cfg, early, .GET, "/rewrite", false));
+    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(std.testing.allocator, &cfg, early, .GET, cfg.metrics_path, false));
+    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(std.testing.allocator, &cfg, early, .GET, "/transcripts", false));
+    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(std.testing.allocator, &cfg, early, .GET, "/missing", false));
 }
 
 test "earlyDataDecisionForRequest rejects matching mirrors before side effects" {
@@ -316,8 +319,8 @@ test "earlyDataDecisionForRequest rejects matching mirrors before side effects" 
     cfg.mirror_rules = mirrors[0..];
 
     const early = http.request_context.EarlyDataContext{ .transport_early = true };
-    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(&cfg, early, .GET, "/safe", false));
-    try std.testing.expectEqual(http.early_data.Decision.execute_local, earlyDataDecisionForRequest(&cfg, early, .HEAD, "/safe", false));
+    try std.testing.expectEqual(http.early_data.Decision.too_early, earlyDataDecisionForRequest(std.testing.allocator, &cfg, early, .GET, "/safe", false));
+    try std.testing.expectEqual(http.early_data.Decision.execute_local, earlyDataDecisionForRequest(std.testing.allocator, &cfg, early, .HEAD, "/safe", false));
 }
 
 test "writeTooEarlyResponse emits no-store 425 without double-counting callers" {
@@ -660,7 +663,7 @@ pub fn routeRequest(
         return status;
     }
 
-    switch (resolveRoute(cfg, request)) {
+    switch (resolveRoute(allocator, cfg, request)) {
         .reload_status => {
             const status = try handleReloadStatusRoute(allocator, writer, state, correlation_id, keep_alive.*);
             state.metricsRecord(status);
@@ -776,7 +779,7 @@ test "enforceLocationAuth records invalid session rejection exactly once" {
     defer request.deinit();
     var output: std.Io.Writer.Allocating = .init(allocator);
     defer output.deinit();
-    const matched = http.location_router.matchLocation(request.uri.path, cfg.location_blocks).?;
+    const matched = http.location_router.matchLocation(allocator, request.uri.path, cfg.location_blocks).?;
 
     const status = (try enforceLocationAuth(allocator, &output.writer, &cfg, &state, &ctx, &request, matched, "req-session", false, "127.0.0.1")).?;
 
@@ -810,7 +813,7 @@ test "enforceLocationAuth records invalid authorization rejection exactly once" 
     defer request.deinit();
     var output: std.Io.Writer.Allocating = .init(allocator);
     defer output.deinit();
-    const matched = http.location_router.matchLocation(request.uri.path, cfg.location_blocks).?;
+    const matched = http.location_router.matchLocation(allocator, request.uri.path, cfg.location_blocks).?;
 
     const status = (try enforceLocationAuth(allocator, &output.writer, &cfg, &state, &ctx, &request, matched, "req-auth", false, "127.0.0.1")).?;
 
@@ -2402,7 +2405,7 @@ fn routeHttp3Location(
     // location routes today; the reload-status and metrics endpoints (which the
     // shared resolver ranks ahead of locations) fall through to the caller's 404
     // — h3 does not expose those operational endpoints yet.
-    const route_decision = resolveRoutePath(ctx.cfg.metrics_path, ctx.cfg.location_blocks, request_path);
+    const route_decision = resolveRoutePath(allocator, ctx.cfg.metrics_path, ctx.cfg.location_blocks, request_path);
 
     var early_ctx = http.request_context.EarlyDataContext{
         .transport_early = request.transport_early,
@@ -2418,6 +2421,7 @@ fn routeHttp3Location(
     }
 
     const decision = earlyDataDecisionForRawMethod(
+        allocator,
         ctx.cfg,
         early_ctx,
         request.method,

--- a/src/gateway_proxy_runtime.zig
+++ b/src/gateway_proxy_runtime.zig
@@ -2239,7 +2239,7 @@ test "proxySuffixPathForLocation uses mount prefix for split upstream exact rout
         },
     };
 
-    const matched = http.location_router.matchLocation("/ursa/health", &blocks).?;
+    const matched = http.location_router.matchLocation(std.testing.allocator, "/ursa/health", &blocks).?;
     const suffix = proxySuffixPathForLocation("/ursa/health", matched, &blocks).?;
     try std.testing.expectEqualStrings("health", suffix);
 }
@@ -2260,7 +2260,7 @@ test "proxySuffixPathForLocation keeps mount prefix for split upstream longer pr
         },
     };
 
-    const matched = http.location_router.matchLocation("/ursa/download/file.bin", &blocks).?;
+    const matched = http.location_router.matchLocation(std.testing.allocator, "/ursa/download/file.bin", &blocks).?;
     const suffix = proxySuffixPathForLocation("/ursa/download/file.bin", matched, &blocks).?;
     try std.testing.expectEqualStrings("download/file.bin", suffix);
 }
@@ -2275,7 +2275,7 @@ test "proxySuffixPathForLocation maps split upstream mount root to slash" {
         },
     };
 
-    const matched = http.location_router.matchLocation("/ursa/", &blocks).?;
+    const matched = http.location_router.matchLocation(std.testing.allocator, "/ursa/", &blocks).?;
     const suffix = proxySuffixPathForLocation("/ursa/", matched, &blocks).?;
     try std.testing.expectEqualStrings("/", suffix);
 }

--- a/src/http/location_router.zig
+++ b/src/http/location_router.zig
@@ -154,7 +154,7 @@ pub const MatchResult = struct {
     matched_path: []const u8,
 };
 
-pub fn matchLocation(request_uri: []const u8, blocks: []const LocationBlock) ?MatchResult {
+pub fn matchLocation(allocator: std.mem.Allocator, request_uri: []const u8, blocks: []const LocationBlock) ?MatchResult {
     const path = normalizeRequestPath(request_uri);
 
     var best_priority_prefix: ?usize = null;
@@ -193,12 +193,12 @@ pub fn matchLocation(request_uri: []const u8, blocks: []const LocationBlock) ?Ma
     for (blocks, 0..) |*block, idx| {
         switch (block.match_type) {
             .regex => {
-                if (rewrite.regexMatchesOptions(block.pattern, path, false)) {
+                if (rewrite.regexMatchesOptionsAlloc(allocator, block.pattern, path, false)) {
                     return .{ .index = idx, .block = block, .matched_path = path };
                 }
             },
             .regex_case_insensitive => {
-                if (rewrite.regexMatchesOptions(block.pattern, path, true)) {
+                if (rewrite.regexMatchesOptionsAlloc(allocator, block.pattern, path, true)) {
                     return .{ .index = idx, .block = block, .matched_path = path };
                 }
             },
@@ -255,7 +255,7 @@ test "exact match beats prefix match" {
         },
     };
 
-    const matched = matchLocation("/status", &blocks).?;
+    const matched = matchLocation(std.testing.allocator, "/status", &blocks).?;
     try std.testing.expectEqual(@as(usize, 1), matched.index);
 }
 
@@ -281,7 +281,7 @@ test "longest prefix priority beats regex and prefix" {
         },
     };
 
-    const matched = matchLocation("/api/private/users", &blocks).?;
+    const matched = matchLocation(std.testing.allocator, "/api/private/users", &blocks).?;
     try std.testing.expectEqual(@as(usize, 2), matched.index);
 }
 
@@ -301,7 +301,7 @@ test "first regex match wins when no priority prefix exists" {
         },
     };
 
-    const matched = matchLocation("/api/users/42", &blocks).?;
+    const matched = matchLocation(std.testing.allocator, "/api/users/42", &blocks).?;
     try std.testing.expectEqual(@as(usize, 0), matched.index);
 }
 
@@ -321,7 +321,7 @@ test "case insensitive regex matches request path without query" {
         },
     };
 
-    const matched = matchLocation("/Assets/SITE.css?v=1", &blocks).?;
+    const matched = matchLocation(std.testing.allocator, "/Assets/SITE.css?v=1", &blocks).?;
     try std.testing.expectEqual(@as(usize, 0), matched.index);
     try std.testing.expectEqualStrings("/Assets/SITE.css", matched.matched_path);
 }
@@ -354,7 +354,7 @@ test "longest plain prefix wins when no exact priority or regex matches" {
         },
     };
 
-    const matched = matchLocation("/images/logo.png", &blocks).?;
+    const matched = matchLocation(std.testing.allocator, "/images/logo.png", &blocks).?;
     try std.testing.expectEqual(@as(usize, 1), matched.index);
 }
 
@@ -374,7 +374,7 @@ test "equal length prefixes keep first configured block" {
         },
     };
 
-    const matched = matchLocation("/api/users", &blocks).?;
+    const matched = matchLocation(std.testing.allocator, "/api/users", &blocks).?;
     try std.testing.expectEqual(@as(usize, 0), matched.index);
 }
 
@@ -408,5 +408,5 @@ fn fuzzMatchLocation(_: void, smith: *std.testing.Smith) !void {
         .value(u8, '#', 1),
         .rangeAtMost(u8, 0x00, 0x1f, 1), // control characters
     });
-    _ = matchLocation(buf[0..len], &fuzz_router_blocks);
+    _ = matchLocation(std.testing.allocator, buf[0..len], &fuzz_router_blocks);
 }

--- a/src/http/rewrite.zig
+++ b/src/http/rewrite.zig
@@ -127,6 +127,8 @@ pub fn regexMatchesOptions(pattern: []const u8, input: []const u8, case_insensit
 }
 
 pub fn regexMatchesOptionsAlloc(allocator: std.mem.Allocator, pattern: []const u8, input: []const u8, case_insensitive: bool) bool {
+    if (anchoredLiteralPrefixCannotMatch(pattern, input, case_insensitive)) return false;
+
     var prepared = preparePattern(allocator, pattern) catch return false;
     defer prepared.deinit();
 
@@ -148,6 +150,29 @@ pub fn regexMatchesOptionsAlloc(allocator: std.mem.Allocator, pattern: []const u
     if (compile_rc != 0) return false;
     defer regfree(&regex);
     return regexec(&regex, input_z_ptr, 0, null, 0) == 0;
+}
+
+fn anchoredLiteralPrefixCannotMatch(pattern: []const u8, input: []const u8, case_insensitive: bool) bool {
+    const prefix = anchoredLiteralPrefix(pattern);
+    if (prefix.len == 0) return false;
+    if (input.len < prefix.len) return true;
+    const input_prefix = input[0..prefix.len];
+    if (!case_insensitive) return !std.mem.eql(u8, input_prefix, prefix);
+    return !std.ascii.eqlIgnoreCase(input_prefix, prefix);
+}
+
+fn anchoredLiteralPrefix(pattern: []const u8) []const u8 {
+    if (pattern.len < 2 or pattern[0] != '^') return "";
+    if (std.mem.indexOfScalar(u8, pattern, '|') != null) return "";
+    var end: usize = 1;
+    while (end < pattern.len) : (end += 1) {
+        switch (pattern[end]) {
+            '*', '?', '{' => return "",
+            '.', '[', ']', '(', ')', '}', '+', '$', '^', '\\' => break,
+            else => {},
+        }
+    }
+    return pattern[1..end];
 }
 
 pub fn evaluate(
@@ -376,6 +401,16 @@ test "regexMatches supports simple pattern" {
 test "regexMatchesOptions supports case-insensitive matches" {
     try std.testing.expect(regexMatchesOptions("^example\\.com$", "Example.COM", true));
     try std.testing.expect(!regexMatchesOptions("^example\\.com$", "Example.COM", false));
+}
+
+test "regexMatchesOptions skips anchored literal prefix misses" {
+    try std.testing.expect(anchoredLiteralPrefixCannotMatch("^/assets/.+\\.css$", "/prefix/health", false));
+    try std.testing.expect(!anchoredLiteralPrefixCannotMatch("^/assets/.+\\.css$", "/assets/site.css", false));
+    try std.testing.expect(!anchoredLiteralPrefixCannotMatch("/assets/.+\\.css$", "/prefix/health", false));
+    try std.testing.expect(anchoredLiteralPrefixCannotMatch("^Example", "other", true));
+    try std.testing.expect(!anchoredLiteralPrefixCannotMatch("^Example", "example-path", true));
+    try std.testing.expect(!anchoredLiteralPrefixCannotMatch("^/assets|/prefix", "/prefix/health", false));
+    try std.testing.expect(!anchoredLiteralPrefixCannotMatch("^/prefix/?health$", "/prefixhealth", false));
 }
 
 test "evaluate applies rewrite and return rules" {

--- a/src/http/rewrite.zig
+++ b/src/http/rewrite.zig
@@ -123,7 +123,10 @@ pub fn regexMatches(pattern: []const u8, input: []const u8) bool {
 }
 
 pub fn regexMatchesOptions(pattern: []const u8, input: []const u8, case_insensitive: bool) bool {
-    const allocator = std.heap.page_allocator;
+    return regexMatchesOptionsAlloc(std.heap.page_allocator, pattern, input, case_insensitive);
+}
+
+pub fn regexMatchesOptionsAlloc(allocator: std.mem.Allocator, pattern: []const u8, input: []const u8, case_insensitive: bool) bool {
     var prepared = preparePattern(allocator, pattern) catch return false;
     defer prepared.deinit();
 

--- a/src/http/rewrite.zig
+++ b/src/http/rewrite.zig
@@ -153,12 +153,11 @@ pub fn regexMatchesOptionsAlloc(allocator: std.mem.Allocator, pattern: []const u
 }
 
 fn anchoredLiteralPrefixCannotMatch(pattern: []const u8, input: []const u8, case_insensitive: bool) bool {
+    if (case_insensitive) return false;
     const prefix = anchoredLiteralPrefix(pattern);
     if (prefix.len == 0) return false;
     if (input.len < prefix.len) return true;
-    const input_prefix = input[0..prefix.len];
-    if (!case_insensitive) return !std.mem.eql(u8, input_prefix, prefix);
-    return !std.ascii.eqlIgnoreCase(input_prefix, prefix);
+    return !std.mem.eql(u8, input[0..prefix.len], prefix);
 }
 
 fn anchoredLiteralPrefix(pattern: []const u8) []const u8 {
@@ -407,8 +406,8 @@ test "regexMatchesOptions skips anchored literal prefix misses" {
     try std.testing.expect(anchoredLiteralPrefixCannotMatch("^/assets/.+\\.css$", "/prefix/health", false));
     try std.testing.expect(!anchoredLiteralPrefixCannotMatch("^/assets/.+\\.css$", "/assets/site.css", false));
     try std.testing.expect(!anchoredLiteralPrefixCannotMatch("/assets/.+\\.css$", "/prefix/health", false));
-    try std.testing.expect(anchoredLiteralPrefixCannotMatch("^Example", "other", true));
-    try std.testing.expect(!anchoredLiteralPrefixCannotMatch("^Example", "example-path", true));
+    try std.testing.expect(!anchoredLiteralPrefixCannotMatch("^Example", "other", true));
+    try std.testing.expect(!anchoredLiteralPrefixCannotMatch("^Ä", "äpfel", true));
     try std.testing.expect(!anchoredLiteralPrefixCannotMatch("^/assets|/prefix", "/prefix/health", false));
     try std.testing.expect(!anchoredLiteralPrefixCannotMatch("^/prefix/?health$", "/prefixhealth", false));
 }

--- a/src/http/tls_termination.zig
+++ b/src/http/tls_termination.zig
@@ -1590,8 +1590,11 @@ fn testUpstreamHandshakeProtocol(
     defer {
         if (server_fd_open) _ = std.c.close(fds[1]);
     }
-    try testSetSocketTimeoutMs(fds[0], 1_000);
-    try testSetSocketTimeoutMs(fds[1], 1_000);
+    // GitHub's ARM runners can stall a native OpenSSL socketpair handshake
+    // long enough for a 1s test timeout to surface as SSL_connect failure
+    // before the ALPN policy assertion is reached.
+    try testSetSocketTimeoutMs(fds[0], 5_000);
+    try testSetSocketTimeoutMs(fds[1], 5_000);
 
     var accept_ctx = ServerAcceptContext{ .terminator = &terminator, .fd = fds[1], .accept_policy = opts.server_accept_policy };
     const thread = try std.Thread.spawn(.{}, serverAcceptThread, .{&accept_ctx});


### PR DESCRIPTION
Closes #143

## Summary

- add allocation ownership documentation for the request lifetime audit
- add deterministic allocation regression rows for header-heavy proxy responses and route matching
- make regex location matching allocator-aware so route-selection scratch is visible to request allocation accounting
- skip full regex preparation for safe case-sensitive anchored-literal prefix misses
- record live base/head evidence for exact/prefix smoke, regex-route proxy matching, repeated prefix-after-regex samples, and streaming proxy paths

## Review updates

- `mixed-route-selection` was split into per-request rows: `mixed-route-exact`, `mixed-route-priority`, `mixed-route-regex`, and `mixed-route-prefix-after-regex`.
- Exact and priority-prefix route rows remain `0 allocs / 0 bytes`; regex match is `4.00 allocs / 181.00 bytes / 146 peak`.
- Added a conservative case-sensitive anchored-literal prefix miss fast path before full POSIX regex preparation; case-insensitive POSIX regexes always fall through to `regcomp`/`regexec` to preserve locale-aware `REG_ICASE` semantics. The prefix-after-regex deterministic row is now `0.00 allocs / 0.00 bytes / 0 peak` for the reviewed anchored miss shape.
- Added `h1-regex-route-arena-reset`, which puts the counter under a request arena, performs two regex route resolutions in one H1-shaped request lifecycle, and verifies live backing bytes return to zero after arena deinit. The measured row is `1.00 alloc / 256.00 bytes / 256 peak`.
- Applied the header-heavy measurement helper to a temporary `main` worktree and recorded the actual base row: base and head both report `4.00 allocs / 1742.00 bytes / 1742 peak`.
- Added same-host live regex-route proxy evidence. The repeated prefix-after-regex closeout used 5 independent 15s samples per build; head no longer reproduces the original p999 regression by median, p99 stays within the same local-run band, and throughput/CPU/RSS are neutral-to-better.
- Ownership docs distinguish H1 request-arena retained backing capacity from H2/H3 dispatch allocator lifetimes; matcher frees are logical, not a universal physical reset boundary.
- Streaming evidence records the actual `proxy_streaming response` server config and metric proof: streaming requests increment, buffered requests stay zero, and fallback counters stay zero.

## Validation

- `zig build bench-allocations`
- `zig build test`
- case-insensitive non-ASCII prefilter regression in `src/http/rewrite.zig`
- `zig build -Doptimize=ReleaseFast`
- temporary `main` worktree measurement-only `zig build bench-allocations` for the header-heavy base row
- repeated prefix-after-regex live evidence: 5 x `benchmarks/run.sh --duration 15 --connections 4 --threads 1 --tool wrk --scenarios proxy-http1 --proxy-path /prefix/health --pid <pid> --save prefix-<build>-<run>.json` for base and head
- `benchmarks/ci-smoke.sh --duration 5 --connections 4 --threads 1 --save <file>` for base/head local fallback evidence
- `benchmarks/run.sh --duration 5 --connections 4 --threads 1 --tool wrk --scenarios proxy-http1 --proxy-path /regex/health --pid <pid>` for regex-match live evidence
- `benchmarks/run.sh --duration 5 --connections 2 --threads 1 --proxy-payload-1m-path /proxy/payload-1m.bin --proxy-slow-client-path /proxy/payload-16m.bin --slow-client-connections 2 --slow-client-limit-rate 2M --scenarios proxy-payload-1m,proxy-slow-client-download --pid <pid>` for base/head local streaming evidence
