### PR TITLE
build: add general-purpose native TLS profile (-Dtls-profile=native) (#634)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
   # Enforces the external-library policy (#379): forbidden TLS/crypto/QUIC/H3
   # dependency names must not be configured, OpenSSL must stay behind the
   # adapter boundary, native paths must be @cImport-free, and produced
-  # appliance/general artifacts must have the expected linkage. This is a
+  # appliance/native/general artifacts must have the expected linkage. This is a
   # required v0.5 release gate for the Bare Systems appliance (#391).
   dependency-audit:
     name: TLS dependency audit
@@ -95,6 +95,16 @@ jobs:
             --binary zig-out/bin/tardi \
             --profile appliance \
             --output "$RUNNER_TEMP/dependency-inventory-appliance.json"
+
+      - name: Build native profile (general-purpose, no OpenSSL, #634)
+        run: zig build -Doptimize=ReleaseFast -Dtls-profile=native
+
+      - name: Audit native artifact linkage
+        run: |
+          ./scripts/audit-release-binary.sh \
+            --binary zig-out/bin/tardi \
+            --profile native \
+            --output "$RUNNER_TEMP/dependency-inventory-native.json"
 
       - name: Build general profile (OpenSSL adapter)
         run: zig build -Doptimize=ReleaseFast -Dtls-profile=general

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,65 @@ jobs:
             exit 1
           fi
 
+  # ── General-purpose native profile tests (#634) ─────────────────────────────
+  # Neither job above exercises `-Dtls-profile=native`: `test` above only
+  # builds `general`, and `test-appliance` above only builds `appliance`.
+  # This job runs the `native` profile's own unit suite plus the
+  # native-listener integration suite (#641 review), and deliberately does
+  # NOT install libssl-dev, so a passing build is itself proof the profile
+  # compiles with no OpenSSL development headers available at all -- not
+  # merely that it happens not to link OpenSSL when headers are present.
+  #
+  # The full `test-integration` suite is intentionally not run here yet:
+  # many of its fixtures (restart/rotation/soak/interop cases) authenticate
+  # against `TARDIGRADE_TLS_SERVER_NAME` the way the appliance profile's
+  # single-identity credential owner treats it -- as the served SNI name --
+  # which the `native` profile's generic multi-identity credential store
+  # does not do (it requires the name to be registered via
+  # `TARDIGRADE_TLS_SNI_CERTS`, matching existing native-H3 behavior).
+  # Wiring the full suite through `native` is tracked as related follow-up
+  # to #634, not a change this slice makes to dozens of unrelated fixtures.
+  test-native:
+    name: Test native profile (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
+          - os: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Zig
+        run: sh ./scripts/install-zig.sh 0.16.0
+
+      - name: Cache Zig build artifacts
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/zig
+            .zig-cache
+          key: zig-test-native-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig') }}-${{ github.sha }}
+          restore-keys: |
+            zig-test-native-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig') }}-
+            zig-test-native-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Print Zig version
+        run: zig version
+
+      - name: Run native profile unit tests
+        run: zig build test -Dtls-profile=native --summary all --error-style verbose
+
+      - name: Run native TLS listener integration tests
+        run: zig build test-integration-native-tls -Dtls-profile=native --summary all --error-style verbose
+
   # ── PKI differential corpus ──────────────────────────────────────────────────
   # Replays the bounded core corpus against the pure-Zig validator, OpenSSL,
   # and Go crypto/x509. External validators remain out of process.

--- a/build.zig
+++ b/build.zig
@@ -1,14 +1,19 @@
 const std = @import("std");
 
-/// TLS/crypto build profile (#379, epic #327). `general` links the single
-/// approved OpenSSL adapter as a compatibility backend; `appliance` is the
-/// Bare Systems profile: no OpenSSL configuration, import, or linkage — the
-/// OpenSSL adapter module is replaced with a native stub at the build graph
-/// level, so `@cImport("openssl/...")` is never analyzed and `libssl`/
-/// `libcrypto` are never linked. There is no runtime fallback between
+/// TLS/crypto build profile (#379, epic #327, cutover #634). `general`
+/// links the single approved OpenSSL adapter as a transitional
+/// compatibility backend. `appliance` and `native` are native-only builds:
+/// no OpenSSL configuration, import, or linkage — the OpenSSL adapter
+/// module is replaced with a native stub at the build graph level, so
+/// `@cImport("openssl/...")` is never analyzed and `libssl`/`libcrypto`
+/// are never linked. `appliance` additionally applies the Bare Systems
+/// product policy (single Ed25519 identity, required server name, fixed
+/// TLS 1.3 policy); `native` is the general-purpose native profile
+/// (multi-identity SNI, generic credential loader) that #634 promotes to
+/// the sole shipping implementation. There is no runtime fallback between
 /// profiles; the selection is embedded in the binary and reported by
 /// `tardi version`. See docs/TLS_DEPENDENCY_POLICY.md.
-const TlsProfile = enum { general, appliance };
+const TlsProfile = enum { general, appliance, native };
 
 /// Resolves the source revision embedded in benchmark/diagnostic metadata
 /// (e.g. `crypto_bench`'s `_meta.tardigrade_commit`, #378's benchmark
@@ -79,7 +84,7 @@ pub fn build(b: *std.Build) void {
     const tls_profile = b.option(
         TlsProfile,
         "tls-profile",
-        "TLS/crypto profile: 'general' (default) links the approved OpenSSL adapter; 'appliance' forbids all foreign TLS/crypto linkage (#379)",
+        "TLS/crypto profile: 'general' (default) links the transitional OpenSSL adapter; 'native' is the general-purpose pure-Zig profile and 'appliance' the Bare Systems policy profile — both forbid all foreign TLS/crypto linkage (#379, #634)",
     ) orelse .general;
     const link_openssl_adapter = tls_profile == .general;
 

--- a/docs/BARE_APPLIANCE_TLS.md
+++ b/docs/BARE_APPLIANCE_TLS.md
@@ -56,7 +56,13 @@ appliance builds; these are OpenSSL-terminator-only features this owner
 never constructs); and if `http3_enabled` is set, a complete identity must
 also be configured and `http3_enable_0rtt`/`http3_connection_migration` must
 be off, and `http3_retry_policy` must remain `off`. Each violation is a
-distinct `UnsupportedApplianceConfiguration` failure, not a silent no-op.
+distinct deterministic failure, not a silent no-op: the OpenSSL-only
+capability checks (version pin, ciphers, mTLS, session cache/tickets,
+OCSP, CRL, ACME, credential watcher, PROXY protocol) are shared with the
+`native` profile and fail with `UnsupportedNativeTlsConfiguration` (#634),
+while the appliance-only policy checks (identity cardinality, server-name
+coupling, HTTP/3 restrictions) fail with
+`UnsupportedApplianceConfiguration`.
 
 ### SNI behavior
 
@@ -201,8 +207,8 @@ into a generic bootstrap error:
 `CertificateKeyUsageViolation`, `CertificateExtendedKeyUsageViolation`,
 `UnhandledCriticalCertificateExtension`, `DuplicateCertificateEntry`,
 `InvalidCertificateChainOrder`, `CertificateSignatureInvalid`,
-`UnsupportedApplianceConfiguration`, `ProviderPublicationFailed`,
-`FileNotFound`, `AccessDenied`, `OutOfMemory`.
+`UnsupportedApplianceConfiguration`, `UnsupportedNativeTlsConfiguration`,
+`ProviderPublicationFailed`, `FileNotFound`, `AccessDenied`, `OutOfMemory`.
 
 Error output never includes key bytes, seeds, DER, signatures, or
 key-derived identifiers.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -248,7 +248,7 @@ the feature or let runtime code choose a fallback. Boolean parsing accepts
 | `TARDIGRADE_HTTP1_ENABLED` | bool | `true` | Enables HTTP/1.1. At least one of HTTP/1.1 or HTTP/2 must stay enabled; plaintext listeners require HTTP/1.1 because downstream h2c is not supported. | `TARDIGRADE_HTTP1_ENABLED=true` |
 | `TARDIGRADE_HTTP2_ENABLED` | bool | `true` | Enables HTTP/2 where supported. HTTP/2-only downstream listeners require TLS. | `TARDIGRADE_HTTP2_ENABLED=true` |
 | `TARDIGRADE_TLS_HTTP1_NO_ALPN_FALLBACK` | bool | `false` | Allows HTTP/1.1 on TLS clients that omit ALPN. | `TARDIGRADE_TLS_HTTP1_NO_ALPN_FALLBACK=true` |
-| `TARDIGRADE_PROXY_PROTOCOL` | enum | `off` | `off`, `auto`, `v1`, `v2`. Appliance TLS profile requires `off`. | `TARDIGRADE_PROXY_PROTOCOL=auto` |
+| `TARDIGRADE_PROXY_PROTOCOL` | enum | `off` | `off`, `auto`, `v1`, `v2`. Appliance/native TLS profiles require `off` when TLS is configured. | `TARDIGRADE_PROXY_PROTOCOL=auto` |
 | `TARDIGRADE_PROXY_STREAMING_MODE` | enum | `off` | `off`/`buffered`, `response`/`responses`, `full`/`request_response`/`request-response`. | `TARDIGRADE_PROXY_STREAMING_MODE=response` |
 | `TARDIGRADE_PROXY_STREAM_BUFFER_SIZE` | bytes | `16384` | 1-1048576; must fit proxy buffer hard limit. | `TARDIGRADE_PROXY_STREAM_BUFFER_SIZE=65536` |
 | `TARDIGRADE_PROXY_STREAM_ALL_STATUSES` | bool | `false` | Stream all upstream statuses instead of mapping non-200 responses. | `TARDIGRADE_PROXY_STREAM_ALL_STATUSES=true` |
@@ -343,33 +343,36 @@ the primary `PROBE_*` names bypass file/secret lookup.
 
 ### TLS Termination
 
-General release binaries use the OpenSSL-backed TLS profile. The
-appliance/native profile has a stricter TLS 1.3-only subset.
+General release binaries use the transitional OpenSSL-backed TLS profile
+(`-Dtls-profile=general`). The native-TLS builds (`-Dtls-profile=appliance`
+and the general-purpose `-Dtls-profile=native`, #634) have a stricter
+TLS 1.3-only subset and deterministically reject OpenSSL-adapter-only
+settings.
 
 | Env key | Type | Default | Valid values / behavior | Example |
 | --- | --- | --- | --- | --- |
 | `TARDIGRADE_TLS_CERT_PATH` | path | `""` | Required for TLS; must be paired with key path. | `TARDIGRADE_TLS_CERT_PATH=/etc/tls/fullchain.pem` |
 | `TARDIGRADE_TLS_KEY_PATH` | path | `""` | Required for TLS; must be paired with cert path. | `TARDIGRADE_TLS_KEY_PATH=/etc/tls/privkey.pem` |
-| `TARDIGRADE_TLS_MIN_VERSION` | string | `1.2` general, `1.3` appliance | General/OpenSSL accepts exactly `1.2` or `1.3`; appliance requires `1.3`. | `TARDIGRADE_TLS_MIN_VERSION=1.2` |
-| `TARDIGRADE_TLS_MAX_VERSION` | string | `1.3` | General/OpenSSL accepts exactly `1.2` or `1.3`; appliance requires `1.3`. | `TARDIGRADE_TLS_MAX_VERSION=1.3` |
-| `TARDIGRADE_TLS_CIPHER_LIST` | string | `""` | OpenSSL TLS <=1.2 cipher list. Appliance profile requires empty. | `TARDIGRADE_TLS_CIPHER_LIST=ECDHE+AESGCM` |
-| `TARDIGRADE_TLS_CIPHER_SUITES` | string | `""` | TLS 1.3 cipher suites. Appliance profile requires empty. | `TARDIGRADE_TLS_CIPHER_SUITES=TLS_AES_256_GCM_SHA384` |
+| `TARDIGRADE_TLS_MIN_VERSION` | string | `1.2` general, `1.3` appliance/native | General/OpenSSL accepts exactly `1.2` or `1.3`; appliance/native require `1.3`. | `TARDIGRADE_TLS_MIN_VERSION=1.2` |
+| `TARDIGRADE_TLS_MAX_VERSION` | string | `1.3` | General/OpenSSL accepts exactly `1.2` or `1.3`; appliance/native require `1.3`. | `TARDIGRADE_TLS_MAX_VERSION=1.3` |
+| `TARDIGRADE_TLS_CIPHER_LIST` | string | `""` | OpenSSL TLS <=1.2 cipher list. Appliance/native profiles require empty. | `TARDIGRADE_TLS_CIPHER_LIST=ECDHE+AESGCM` |
+| `TARDIGRADE_TLS_CIPHER_SUITES` | string | `""` | TLS 1.3 cipher suites. Appliance/native profiles require empty. | `TARDIGRADE_TLS_CIPHER_SUITES=TLS_AES_256_GCM_SHA384` |
 | `TARDIGRADE_TLS_SERVER_NAME` | DNS name | `""` | Unused by the general/OpenSSL terminator. Appliance requires one non-wildcard DNS name when TLS is enabled; appliance credential/name changes require restart. | `TARDIGRADE_TLS_SERVER_NAME=edge.example.com` |
 | `TARDIGRADE_TLS_SNI_CERTS` | encoded list | `""` | Additional SNI certs as <code>name:cert:key&#124;name2:cert2:key2</code>. Appliance profile requires empty. | `TARDIGRADE_TLS_SNI_CERTS=api.example.com:/a.crt:/a.key` |
-| `TARDIGRADE_TLS_SESSION_CACHE` | bool | `true` general, `false` appliance | OpenSSL session cache. Appliance profile rejects true. | `TARDIGRADE_TLS_SESSION_CACHE=true` |
+| `TARDIGRADE_TLS_SESSION_CACHE` | bool | `true` general, `false` appliance/native | OpenSSL session cache. Appliance/native profiles reject true (see `TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE`). | `TARDIGRADE_TLS_SESSION_CACHE=true` |
 | `TARDIGRADE_TLS_SESSION_CACHE_SIZE` | u32 | `20480` | OpenSSL session cache size. | `TARDIGRADE_TLS_SESSION_CACHE_SIZE=40960` |
 | `TARDIGRADE_TLS_SESSION_TIMEOUT_SECONDS` | u32 | `300` | OpenSSL session timeout. | `TARDIGRADE_TLS_SESSION_TIMEOUT_SECONDS=600` |
-| `TARDIGRADE_TLS_SESSION_TICKETS` | bool | `true` general, `false` appliance | OpenSSL ticket support. Appliance profile rejects true. | `TARDIGRADE_TLS_SESSION_TICKETS=true` |
+| `TARDIGRADE_TLS_SESSION_TICKETS` | bool | `true` general, `false` appliance/native | OpenSSL ticket support. Appliance/native profiles reject true (see `TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE`). | `TARDIGRADE_TLS_SESSION_TICKETS=true` |
 | `TARDIGRADE_TLS_HANDSHAKE_TIMEOUT_MS` | u32 ms | `5000` | TLS handshake read timeout. `0` falls back to keep-alive timeout. | `TARDIGRADE_TLS_HANDSHAKE_TIMEOUT_MS=3000` |
-| `TARDIGRADE_TLS_DYNAMIC_RELOAD_INTERVAL_MS` | u64 ms | `5000` general, `0` appliance | OpenSSL cert/key watcher interval. Appliance profile requires `0`. | `TARDIGRADE_TLS_DYNAMIC_RELOAD_INTERVAL_MS=5000` |
+| `TARDIGRADE_TLS_DYNAMIC_RELOAD_INTERVAL_MS` | u64 ms | `5000` general, `0` appliance/native | OpenSSL cert/key watcher interval. Appliance/native profiles require `0`. | `TARDIGRADE_TLS_DYNAMIC_RELOAD_INTERVAL_MS=5000` |
 | `TARDIGRADE_TLS_CLIENT_CA_PATH` | path | `""` | Required when `TARDIGRADE_TLS_CLIENT_VERIFY=true`. | `TARDIGRADE_TLS_CLIENT_CA_PATH=/etc/tls/clients.pem` |
-| `TARDIGRADE_TLS_CLIENT_VERIFY` | bool | `false` | Downstream client cert verification. Appliance profile rejects true. | `TARDIGRADE_TLS_CLIENT_VERIFY=true` |
+| `TARDIGRADE_TLS_CLIENT_VERIFY` | bool | `false` | Downstream client cert verification. Appliance/native profiles reject true. | `TARDIGRADE_TLS_CLIENT_VERIFY=true` |
 | `TARDIGRADE_TLS_CLIENT_VERIFY_DEPTH` | u32 | `3` | Client certificate chain depth. | `TARDIGRADE_TLS_CLIENT_VERIFY_DEPTH=4` |
 | `TARDIGRADE_TLS_CRL_PATH` | path | `""` | CRL file. | `TARDIGRADE_TLS_CRL_PATH=/etc/tls/revoked.pem` |
-| `TARDIGRADE_TLS_CRL_CHECK` | bool | `false` | Enable CRL checking. Appliance profile rejects true. | `TARDIGRADE_TLS_CRL_CHECK=true` |
-| `TARDIGRADE_TLS_OCSP_STAPLING` | bool | `false` | Enable OCSP stapling. Appliance profile rejects true. | `TARDIGRADE_TLS_OCSP_STAPLING=true` |
+| `TARDIGRADE_TLS_CRL_CHECK` | bool | `false` | Enable CRL checking. Appliance/native profiles reject true. | `TARDIGRADE_TLS_CRL_CHECK=true` |
+| `TARDIGRADE_TLS_OCSP_STAPLING` | bool | `false` | Enable OCSP stapling. Appliance/native profiles reject true. | `TARDIGRADE_TLS_OCSP_STAPLING=true` |
 | `TARDIGRADE_TLS_OCSP_RESPONSE_PATH` | path | `""` | DER OCSP response path. | `TARDIGRADE_TLS_OCSP_RESPONSE_PATH=/var/cache/ocsp.der` |
-| `TARDIGRADE_TLS_OCSP_AUTO_REFRESH` | bool | `false` | Refresh OCSP response automatically. Appliance profile rejects true. | `TARDIGRADE_TLS_OCSP_AUTO_REFRESH=true` |
+| `TARDIGRADE_TLS_OCSP_AUTO_REFRESH` | bool | `false` | Refresh OCSP response automatically. Appliance/native profiles reject true. | `TARDIGRADE_TLS_OCSP_AUTO_REFRESH=true` |
 | `TARDIGRADE_TLS_OCSP_REFRESH_INTERVAL_MS` | u64 ms | `3600000` | OCSP refresh interval. | `TARDIGRADE_TLS_OCSP_REFRESH_INTERVAL_MS=1800000` |
 | `TARDIGRADE_TLS_OCSP_REFRESH_TIMEOUT_MS` | u32 ms | `10000` | OCSP refresh timeout. | `TARDIGRADE_TLS_OCSP_REFRESH_TIMEOUT_MS=5000` |
 
@@ -417,7 +420,7 @@ TLS stream capacity. Defaults are deterministic from native stream queue capacit
 
 | Env key | Type | Default | Valid values / behavior | Example |
 | --- | --- | --- | --- | --- |
-| `TARDIGRADE_TLS_ACME_ENABLED` | bool | `false` | Enable ACME. Appliance profile rejects true. | `TARDIGRADE_TLS_ACME_ENABLED=true` |
+| `TARDIGRADE_TLS_ACME_ENABLED` | bool | `false` | Enable ACME. Appliance/native profiles reject true (native ACME is tracked by #634). | `TARDIGRADE_TLS_ACME_ENABLED=true` |
 | `TARDIGRADE_TLS_ACME_CERT_DIR` | path | `""` | Certificate storage directory. | `TARDIGRADE_TLS_ACME_CERT_DIR=/var/lib/tardigrade/acme` |
 | `TARDIGRADE_TLS_ACME_DIRECTORY_URL` | URL | `https://acme-v02.api.letsencrypt.org/directory` | ACME directory URL. | `TARDIGRADE_TLS_ACME_DIRECTORY_URL=https://acme-staging-v02.api.letsencrypt.org/directory` |
 | `TARDIGRADE_TLS_ACME_DOMAINS` | CSV DNS names | `[]` | Domains to obtain/renew. Empty logs a warning when ACME is enabled. | `TARDIGRADE_TLS_ACME_DOMAINS=example.com,www.example.com` |

--- a/docs/RELOAD_SHUTDOWN.md
+++ b/docs/RELOAD_SHUTDOWN.md
@@ -114,8 +114,10 @@ and which protocols a deployment serves:
   that is not part of `SIGHUP` reload and does not respond to a changed
   `TLS_CERT_PATH`/`TLS_KEY_PATH` value.
 - The **native credential store** (`http.native_tls_connection.NativeCredentialStore`),
-  used for native HTTP/3 on the `general` build (the appliance profile uses
-  `ApplianceCredentials` for HTTP/3 too — see below). It supports a real
+  used for native HTTP/3 on the `general` build, and for *both* native TCP
+  and native HTTP/3 on the general-purpose native build
+  (`tls-profile=native`, #634); the appliance profile uses
+  `ApplianceCredentials` for both — see below. It supports a real
   prepare/commit hot-swap of certificate, key, and SNI identity from the
   proposed reload paths, and `hotReloadConfig` uses that capability on
   every accepted `SIGHUP` where it applies (see below).
@@ -126,10 +128,11 @@ and which protocols a deployment serves:
   reload outright via `applianceCredentialConfigChanged` for any change to
   `TLS_CERT_PATH`/`TLS_KEY_PATH`/`TLS_SERVER_NAME`/`TLS_SNI_CERTS`, so in
   practice appliance credentials are fully startup-owned — a `SIGHUP` never
-  changes what either protocol serves. (There is currently no shipping
-  profile where a live-reloadable `NativeCredentialStore` is shared between
-  native TCP and native HTTP/3; today's two profiles are `general`, above,
-  and `appliance`, here.)
+  changes what either protocol serves. (On the `native` profile, by
+  contrast, one live-reloadable `NativeCredentialStore` is shared between
+  native TCP and native HTTP/3, so a single accepted `SIGHUP` rotates both
+  surfaces to the same identity atomically — the #629 split-identity
+  hazard is structural to the mixed `general`+H3 composition only.)
 
 **On the default `general` build with the OpenSSL adapter linked**, stable
 TCP owns its identity via `TlsTerminator` (startup-owned, as above) while

--- a/docs/RELOAD_SHUTDOWN.md
+++ b/docs/RELOAD_SHUTDOWN.md
@@ -132,7 +132,12 @@ and which protocols a deployment serves:
   contrast, one live-reloadable `NativeCredentialStore` is shared between
   native TCP and native HTTP/3, so a single accepted `SIGHUP` rotates both
   surfaces to the same identity atomically — the #629 split-identity
-  hazard is structural to the mixed `general`+H3 composition only.)
+  hazard is structural to the mixed `general`+H3 composition only. TLS
+  *topology* is still startup-owned on every native build: the store and
+  provider are created only when cert/key paths exist at startup, so
+  `hotReloadConfig` rejects any reload that would turn TLS on for a
+  process that started plaintext, or off for one that started with TLS —
+  "enabling or disabling native TLS requires restart".)
 
 **On the default `general` build with the OpenSSL adapter linked**, stable
 TCP owns its identity via `TlsTerminator` (startup-owned, as above) while

--- a/docs/TLS_DEPENDENCY_POLICY.md
+++ b/docs/TLS_DEPENDENCY_POLICY.md
@@ -1,24 +1,32 @@
-# TLS/crypto dependency policy and pure-Zig cutover (#379, epic #327)
+# TLS/crypto dependency policy and pure-Zig cutover (#379, epic #327, #634)
 
 This note records Tardigrade's external-library policy for TLS, crypto, QUIC,
 HTTP/3, and certificate handling, how that policy is enforced in source, build
 configuration, CI, and release artifacts, and the checklist that governs the
-cutover to the pure-Zig implementation. It is the deliverable of research story
-**327-J** and a required v0.5 release gate for the Bare Systems appliance
-(#391).
+cutover to the pure-Zig implementation. It began as the deliverable of
+research story **327-J** and a required v0.5 release gate for the Bare Systems
+appliance (#391); the canonical architecture owner is now **#634**.
 
 ## Why
 
-Tardigrade is moving its TLS/crypto stack from OpenSSL to a pure-Zig
-implementation (epic #327). During that transition two products ship from one
-tree, and their dependency rules differ:
+The project architecture (#634) is that **the native Zig TLS/crypto/PKI/QUIC/
+HTTP implementation is the only implementation that ships to users**:
 
-- The **Bare Systems appliance** must contain no OpenSSL or other foreign
-  TLS/crypto implementation at all — no linkage, no configuration, no hidden
-  runtime fallback.
-- **General-purpose Tardigrade** may keep a single, narrowly isolated OpenSSL
-  adapter as a compatibility backend until the native path reaches the v1.0
-  support contract.
+- Every distributed `tardi` artifact — release archives, packages, containers,
+  Homebrew, installer paths — must be built on the native implementation, with
+  no OpenSSL or other foreign TLS/crypto/QUIC/H3 library linked, configured,
+  or reachable through a hidden runtime fallback.
+- External implementations (OpenSSL, GnuTLS, independent QUIC stacks, …)
+  remain encouraged as **test, interoperability, differential-validation, and
+  benchmark infrastructure**, always outside the shipping link/runtime graph.
+- Appliance vs. general-purpose differences are **product policy** expressed
+  on the same native implementation (cipher/identity/lifecycle policy), not a
+  choice of implementation backend.
+
+During the remaining transition the default `general` build profile still
+links the single, narrowly isolated OpenSSL adapter as a compatibility
+backend. That composition is transitional: it is not a permitted final
+shipping backend, and no new architecture should make it more permanent.
 
 A policy that is only written down drifts. This one is enforced by the build
 graph and by CI, and every release artifact makes its selected profile and
@@ -31,21 +39,48 @@ the binary. There is no runtime switch and no fallback between profiles.
 
 ### Bare Systems appliance profile (`-Dtls-profile=appliance`)
 
-- Uses the native Zig TLS/crypto path only.
+- Uses the native Zig TLS/crypto path only, with the strict Bare Systems
+  product policy on top: a single Ed25519 identity, a required
+  `TARDIGRADE_TLS_SERVER_NAME`, TLS 1.3 only, restart-owned credential
+  rotation. The supported TLS/certificate/client matrix is defined by #391.
 - Must not link `libssl`, `libcrypto`, or any other foreign TLS, crypto, QUIC,
   HTTP/3, or certificate library.
 - The OpenSSL adapter module (`src/http/tls_termination.zig`) is **replaced in
   the module graph** by a no-OpenSSL stub (`src/http/tls_termination_stub.zig`)
   via `src/http/tls_backend.zig`. Because the adapter source is never imported,
   its `@cImport("openssl/...")` is never analyzed and OpenSSL is never linked.
-- Until the native TLS termination path lands, the stub fails closed at startup
-  (`error.ContextInitFailed`) rather than silently degrading. The supported
-  TLS/certificate/client matrix for the appliance is defined by #391.
+  Live termination runs on `src/http/native_tls_connection.zig`; the stub only
+  fills the module graph and fails closed (`error.ContextInitFailed`) if
+  anything ever reaches it.
 
-### General-purpose profile (`-Dtls-profile=general`, default)
+### General-purpose native profile (`-Dtls-profile=native`, #634)
 
-- Links the single approved OpenSSL adapter as a compatibility/reference
-  backend.
+- The general-purpose expression of the same native implementation: generic
+  multi-identity credential loading (default cert/key plus
+  `TARDIGRADE_TLS_SNI_CERTS`), native TCP TLS termination, native QUIC/H3,
+  SIGHUP-driven credential reload, opt-in native resumption
+  (`TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE`). The credential store is
+  fail-closed on SNI, matching the existing native HTTP/3 behavior: the
+  default identity serves clients that send no SNI, and every host name
+  clients will request must be registered via `TARDIGRADE_TLS_SNI_CERTS`
+  (default-identity SAN matching is part of the remaining #634 parity
+  work).
+- Must not link `libssl`, `libcrypto`, or any other foreign TLS, crypto, QUIC,
+  HTTP/3, or certificate library — audited identically to the appliance
+  profile.
+- OpenSSL-adapter-only settings (TLS 1.2, cipher-string overrides, mTLS client
+  verification, the OpenSSL session cache/tickets, OCSP stapling, CRL checks,
+  ACME, the filesystem credential watcher, PROXY protocol with TLS) fail
+  config validation deterministically (`UnsupportedNativeTlsConfiguration`)
+  instead of being silently ignored; each is either natively implemented later
+  or explicitly dispositioned under #634.
+- This is the profile #634 promotes to the shipping default once feature
+  disposition and release/packaging cutover complete.
+
+### General-purpose OpenSSL profile (`-Dtls-profile=general`, default, transitional)
+
+- Links the single approved OpenSSL adapter as a transitional
+  compatibility/reference backend; superseded as a shipping backend by #634.
 - OpenSSL types and state stay behind the adapter boundary
   (`src/http/tls_termination.zig`, `src/http/acme_client.zig`) and must not
   shape TLS, HTTP, QUIC, PKI, or application interfaces.
@@ -71,6 +106,8 @@ audits can verify an artifact without inspecting its link graph:
 $ tardi version
 0.5.0 (tls-profile=appliance, tls-backend=native)
 $ tardi version
+0.5.0 (tls-profile=native, tls-backend=native)
+$ tardi version
 0.5.0 (tls-profile=general, tls-backend=openssl-adapter)
 ```
 
@@ -94,8 +131,8 @@ Runs before anything is compiled and fails if:
 Inspects a produced binary's dynamic dependencies (`ldd` on Linux, `otool -L`
 on macOS) and emits a machine-readable JSON inventory. It fails if:
 
-- an appliance artifact links OpenSSL or any forbidden foreign library, or does
-  not self-report the native TLS path; or
+- an appliance or native artifact links OpenSSL or any forbidden foreign
+  library, or does not self-report the native TLS path; or
 - a general artifact's actual linkage disagrees with its self-reported backend
   (so the inventory cannot lie).
 
@@ -105,7 +142,7 @@ self-reported backend, full dependency list, and any violations.
 ### CI
 
 The `TLS dependency audit` job in `.github/workflows/ci.yml` runs the source
-audit, builds **both** profiles, and runs the binary audit against each,
+audit, builds **all three** profiles, and runs the binary audit against each,
 uploading the inventories as artifacts. It is a required check: CI fails if any
 forbidden implementation is configured, imported, or linked in any profile.
 
@@ -126,24 +163,32 @@ alongside the release assets and SBOM.
       build-graph decision).
 - [x] Appliance artifact self-reports the native TLS path.
 - [x] CI builds and audits the appliance artifact on every change.
-- [ ] Native TLS termination and client paths implement the #391 appliance
-      support matrix (handshake, certificate verification, session resumption).
-      **Until this lands the appliance profile compiles and audits clean but
-      refuses TLS connections at runtime.**
-- [ ] Appliance integration/interop coverage proves live operation through the
-      native path.
+- [x] Native TLS termination serves live appliance connections
+      (`src/http/native_tls_connection.zig`); CI runs the appliance unit and
+      integration suites on every change.
+- [ ] #391 appliance certification (exact-artifact/device/product-policy
+      gate) complete.
 
-### General-purpose native-TLS parity (governs OpenSSL adapter removal)
+### General-purpose native cutover (#634; governs OpenSSL adapter removal)
 
 - [x] OpenSSL confined to the adapter boundary; no OpenSSL types in TLS/HTTP/
       QUIC/PKI/application interfaces (enforced by source audit).
 - [x] General artifacts expose a complete dependency inventory and identify the
       selected backend.
+- [x] A general-purpose native profile exists (`-Dtls-profile=native`): no
+      foreign linkage, generic multi-identity credentials, deterministic
+      rejection of OpenSSL-adapter-only settings, built and binary-audited in
+      CI.
+- [ ] Every operator-visible OpenSSL-path capability (mTLS, OCSP, CRL, ACME,
+      TLS 1.2, cipher policy, watcher-based reload, upstream TLS) is migrated
+      to native code or explicitly dispositioned per #634.
 - [ ] Native TLS reaches the v1.0 general-purpose support contract
       (`docs/SUPPORT_MATRIX.md`).
 - [ ] Native path passes the TLS/interop conformance suite at parity with the
       OpenSSL adapter.
-- [ ] Default profile flips from `general` to native once parity holds.
+- [ ] Default profile flips from `general` to `native` once parity holds.
+- [ ] Release/package/container/Homebrew artifacts ship the native profile and
+      pass the no-foreign-linkage audit (#634 distribution criteria).
 - [ ] OpenSSL adapter removed from all builds; `configureSsl`, the adapter
       modules, and the general profile retired.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -853,6 +853,13 @@ default build, and conflating them leads to false confidence:
    additionally runs the appliance credential preflight (PEM parse,
    chain shape, leaf/key match, validity-window checks), so it catches
    the supported material/validity failures earlier, at `check` time.
+5. **Native general-purpose profile (`-Dtls-profile=native`, #634):**
+   `tardi check` is config-shape validation like the general profile, but
+   OpenSSL-adapter-only settings (TLS 1.2, cipher overrides, mTLS, session
+   cache/tickets, OCSP, CRL, ACME, the credential watcher, PROXY protocol
+   with TLS) are rejected deterministically at `check` time. Credential
+   parse/mismatch failures surface when `tardi run` loads the files into
+   the native credential store at startup.
 
 Confirm which profile you're running with `tardi version` (it prints
 `tls-profile=...`) before assuming which of the above applies.

--- a/scripts/audit-release-binary.sh
+++ b/scripts/audit-release-binary.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
-# TLS/crypto binary linkage audit and dependency inventory (#379, epic #327).
+# TLS/crypto binary linkage audit and dependency inventory (#379, epic #327,
+# cutover #634).
 #
 # Inspects a produced tardi binary's dynamic dependencies and emits a
-# machine-readable inventory. For the Bare Systems appliance profile it fails
-# if the binary links OpenSSL, libcrypto, or any other foreign TLS/crypto/
-# QUIC/H3/certificate library, and confirms the binary self-reports the
-# native TLS path. For the general profile it records whether the OpenSSL
-# adapter was selected and lists the full dependency set.
+# machine-readable inventory. For the native-only profiles (`appliance` and
+# `native`) it fails if the binary links OpenSSL, libcrypto, or any other
+# foreign TLS/crypto/QUIC/H3/certificate library, and confirms the binary
+# self-reports the native TLS path. For the transitional general profile it
+# records whether the OpenSSL adapter was selected and lists the full
+# dependency set.
 #
 # Usage:
-#   audit-release-binary.sh --binary PATH --profile {general|appliance} \
+#   audit-release-binary.sh --binary PATH --profile {general|appliance|native} \
 #       [--output inventory.json]
 #
 # Exit code 0 means the audit passed. A forbidden linkage, or a profile that
@@ -23,7 +25,7 @@ OUTPUT=""
 
 usage() {
     cat <<'EOF'
-Usage: audit-release-binary.sh --binary PATH --profile {general|appliance} [--output FILE]
+Usage: audit-release-binary.sh --binary PATH --profile {general|appliance|native} [--output FILE]
 EOF
 }
 
@@ -62,16 +64,17 @@ if [ ! -f "$BINARY" ]; then
     exit 2
 fi
 case "$PROFILE" in
-general | appliance) ;;
+general | appliance | native) ;;
 *)
-    echo "invalid profile: $PROFILE (expected general or appliance)" >&2
+    echo "invalid profile: $PROFILE (expected general, appliance, or native)" >&2
     exit 2
     ;;
 esac
 
 # Foreign TLS/crypto/QUIC/H3/certificate libraries that must never appear in a
 # Tardigrade link graph. openssl/crypto are handled separately: forbidden in
-# the appliance profile, the approved adapter in the general profile.
+# the native-only profiles (appliance/native), the approved transitional
+# adapter in the general profile.
 FORBIDDEN_LIB_PATTERNS='ngtcp2|nghttp3|quiche|boringssl|mbedtls|wolfssl|gnutls|libtls|libressl|botan|s2n'
 
 # ── Collect dynamic dependencies across platforms ────────────────────────────
@@ -170,12 +173,12 @@ if [ "$reported_profile" != "$PROFILE" ]; then
     violations+=("artifact self-reports tls-profile '$reported_profile' but was audited as '$PROFILE'")
 fi
 
-if [ "$PROFILE" = "appliance" ]; then
+if [ "$PROFILE" = "appliance" ] || [ "$PROFILE" = "native" ]; then
     if [ "$links_openssl" = true ]; then
-        violations+=("appliance artifact links OpenSSL (libssl/libcrypto)")
+        violations+=("$PROFILE artifact links OpenSSL (libssl/libcrypto)")
     fi
     if [ "$reported_backend" != "native" ]; then
-        violations+=("appliance artifact does not self-report the native TLS path (got '$reported_backend')")
+        violations+=("$PROFILE artifact does not self-report the native TLS path (got '$reported_backend')")
     fi
 else
     # General profile: OpenSSL is permitted, but the binary's self-report must

--- a/src/config_reference.zig
+++ b/src/config_reference.zig
@@ -397,9 +397,9 @@ pub const entries = [_]ConfigEntry{
         .name = "tls_min_version",
         .contexts = CTX_TOP,
         .value_type = "enum",
-        .default_value = "1.2 (general profile); 1.3 (appliance profile)",
+        .default_value = "1.2 (general profile); 1.3 (appliance and native profiles)",
         .valid_values = &.{ "1.2", "1.3" },
-        .description = "Minimum negotiated TLS protocol version. The appliance TLS profile requires 1.3 for both min and max.",
+        .description = "Minimum negotiated TLS protocol version. The native-TLS builds (appliance and native profiles) require 1.3 for both min and max.",
         .example = "tls_min_version 1.2;",
         .env_vars = &.{"TARDIGRADE_TLS_MIN_VERSION"},
         .docs = &.{"docs/TLS_INTEROP_MATRIX.md"},
@@ -409,7 +409,7 @@ pub const entries = [_]ConfigEntry{
         .contexts = CTX_TOP,
         .value_type = "enum",
         .default_value = "1.3",
-        .valid_values = &.{"1.2, 1.3 (general profile); 1.3 only (appliance profile -- must match tls_min_version)"},
+        .valid_values = &.{"1.2, 1.3 (general profile); 1.3 only (appliance and native profiles -- must match tls_min_version)"},
         .description = "Maximum negotiated TLS protocol version.",
         .example = "tls_max_version 1.3;",
         .env_vars = &.{"TARDIGRADE_TLS_MAX_VERSION"},
@@ -422,7 +422,7 @@ pub const entries = [_]ConfigEntry{
         .default_value = "false",
         .valid_values = &.{ "true", "false" },
         .value_aliases = &.{.{ .alias = "1", .canonical = "true" }},
-        .description = "Requires and verifies client certificates (mTLS). Rejected by the appliance TLS profile: true is not a valid value in appliance builds.",
+        .description = "Requires and verifies client certificates (mTLS). Rejected by the native-TLS builds: true is not a valid value in appliance or native profile builds.",
         .example = "tls_client_verify true;",
         .env_vars = &.{"TARDIGRADE_TLS_CLIENT_VERIFY"},
         .docs = &.{"docs/PENTEST_PLAYBOOK.md"},
@@ -444,7 +444,7 @@ pub const entries = [_]ConfigEntry{
         .default_value = "false",
         .valid_values = &.{ "true", "false" },
         .value_aliases = &.{.{ .alias = "1", .canonical = "true" }},
-        .description = "Enables OCSP stapling responses. Not supported when the binary is built with the appliance TLS profile.",
+        .description = "Enables OCSP stapling responses. Not supported when the binary is built with the appliance or native TLS profiles.",
         .example = "tls_ocsp_stapling true;",
         .env_vars = &.{"TARDIGRADE_TLS_OCSP_STAPLING"},
         .docs = &.{"docs/PKI_REVOCATION.md"},
@@ -1825,7 +1825,7 @@ test "writeExplanation represents profile-dependent tls_min_version truthfully" 
     try writeExplanation(&out.writer, lookup("tls_min_version").?);
     const written = out.writer.buffered();
     try std.testing.expect(std.mem.indexOf(u8, written, "general profile") != null);
-    try std.testing.expect(std.mem.indexOf(u8, written, "appliance profile") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "appliance and native profiles") != null);
 }
 
 test "writeUnknown names the query and suggests a close match" {

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -832,12 +832,13 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
 
     var tls_key_path = envOrDefault(allocator, "TARDIGRADE_TLS_KEY_PATH", "") catch unreachable;
     errdefer allocator.free(tls_key_path);
-    // The appliance profile's native engine is TLS 1.3-only regardless of
-    // this setting; default it to "1.3" there instead of the general
-    // profile's "1.2" so an operator who never touches it gets a config
-    // that accurately describes what the engine does, and an explicit
-    // override to anything else is caught by validateApplianceTlsProfile.
-    const tls_min_version = envOrDefault(allocator, "TARDIGRADE_TLS_MIN_VERSION", if (is_appliance_tls_profile) "1.3" else "1.2") catch unreachable;
+    // The native engine (appliance/native profiles) is TLS 1.3-only
+    // regardless of this setting; default it to "1.3" there instead of the
+    // general profile's "1.2" so an operator who never touches it gets a
+    // config that accurately describes what the engine does, and an
+    // explicit override to anything else is caught by
+    // validateNativeTlsBuildConfig.
+    const tls_min_version = envOrDefault(allocator, "TARDIGRADE_TLS_MIN_VERSION", if (is_native_tls_build) "1.3" else "1.2") catch unreachable;
     errdefer allocator.free(tls_min_version);
     const tls_max_version = envOrDefault(allocator, "TARDIGRADE_TLS_MAX_VERSION", "1.3") catch unreachable;
     errdefer allocator.free(tls_max_version);
@@ -858,15 +859,16 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
         }
         allocator.free(tls_sni_certs);
     }
-    // Session cache/tickets are OpenSSL-terminator-only features this
-    // owner never constructs in the appliance profile; default them off
-    // there (general profile keeps its on-by-default resumption behavior)
-    // so an operator who never touches these gets an accurate config, and
-    // an explicit override to `true` is caught by validateApplianceTlsProfile.
-    const tls_session_cache_enabled = parseBoolEnv(allocator, "TARDIGRADE_TLS_SESSION_CACHE", !is_appliance_tls_profile);
+    // Session cache/tickets are OpenSSL-terminator-only features that
+    // native-TLS builds never construct; default them off there (general
+    // profile keeps its on-by-default resumption behavior) so an operator
+    // who never touches these gets an accurate config, and an explicit
+    // override to `true` is caught by validateNativeTlsBuildConfig.
+    // Native resumption is the separate #488 `tls_native_*` surface below.
+    const tls_session_cache_enabled = parseBoolEnv(allocator, "TARDIGRADE_TLS_SESSION_CACHE", !is_native_tls_build);
     const tls_session_cache_size = parseIntEnv(u32, allocator, "TARDIGRADE_TLS_SESSION_CACHE_SIZE", 20_480);
     const tls_session_timeout_seconds = parseIntEnv(u32, allocator, "TARDIGRADE_TLS_SESSION_TIMEOUT_SECONDS", 300);
-    const tls_session_tickets_enabled = parseBoolEnv(allocator, "TARDIGRADE_TLS_SESSION_TICKETS", !is_appliance_tls_profile);
+    const tls_session_tickets_enabled = parseBoolEnv(allocator, "TARDIGRADE_TLS_SESSION_TICKETS", !is_native_tls_build);
     // #488: native resumption defaults to disabled/safe regardless of TLS
     // profile — this is a distinct opt-in surface from the OpenSSL-facing
     // `tls_session_*` settings above and is validated deterministically in
@@ -904,12 +906,13 @@ pub fn loadFromEnv(allocator: std.mem.Allocator) !EdgeConfig {
     const tls_crl_path = envOrDefault(allocator, "TARDIGRADE_TLS_CRL_PATH", "") catch unreachable;
     errdefer allocator.free(tls_crl_path);
     const tls_crl_check = parseBoolEnv(allocator, "TARDIGRADE_TLS_CRL_CHECK", false);
-    // Dynamic file-watching is an OpenSSL-terminator-only feature this
-    // owner never constructs in the appliance profile; default it off
-    // there (general profile keeps its on-by-default watcher) so an
-    // operator who never touches this gets an accurate config, and an
-    // explicit nonzero override is caught by validateApplianceTlsProfile.
-    const tls_dynamic_reload_interval_ms = parseIntEnv(u64, allocator, "TARDIGRADE_TLS_DYNAMIC_RELOAD_INTERVAL_MS", if (is_appliance_tls_profile) 0 else 5000);
+    // Dynamic file-watching is an OpenSSL-terminator-only feature that
+    // native-TLS builds never construct (native credential rotation is the
+    // explicit SIGHUP reload path); default it off there (general profile
+    // keeps its on-by-default watcher) so an operator who never touches
+    // this gets an accurate config, and an explicit nonzero override is
+    // caught by validateNativeTlsBuildConfig.
+    const tls_dynamic_reload_interval_ms = parseIntEnv(u64, allocator, "TARDIGRADE_TLS_DYNAMIC_RELOAD_INTERVAL_MS", if (is_native_tls_build) 0 else 5000);
     const tls_acme_enabled = parseBoolEnv(allocator, "TARDIGRADE_TLS_ACME_ENABLED", false);
     const tls_acme_cert_dir = envOrDefault(allocator, "TARDIGRADE_TLS_ACME_CERT_DIR", "") catch unreachable;
     errdefer allocator.free(tls_acme_cert_dir);
@@ -2872,6 +2875,13 @@ pub fn hasTlsFiles(cfg: *const EdgeConfig) bool {
 pub const is_appliance_tls_profile =
     std.mem.eql(u8, build_options.tls_profile, "appliance");
 
+/// True when this binary was built without the OpenSSL adapter
+/// (`-Dtls-profile=appliance` or `-Dtls-profile=native`, #634): TCP TLS
+/// termination runs on the native pure-Zig path and every
+/// OpenSSL-adapter-only capability must fail deterministically at config
+/// validation instead of being silently ignored.
+pub const is_native_tls_build = !build_options.tls_openssl_adapter;
+
 /// #488: native (pure-Zig) resumption mode this config resolves to. Callers
 /// must only rely on this after `validate()` has succeeded — an unrecognized
 /// raw string falls back to `.disabled`, the safe default, rather than
@@ -2982,6 +2992,64 @@ fn validateTlsServerNamePolicy(cfg: *const EdgeConfig) !void {
 /// appliance-appropriate defaults for `tls_min_version` and the session
 /// cache/ticket flags), so a config that never touches these settings
 /// always passes.
+/// #634: capability gate shared by every native-TLS build
+/// (`-Dtls-profile=appliance` and `-Dtls-profile=native`). These are
+/// implementation limits of the native TCP TLS path — settings only the
+/// OpenSSL adapter implements must fail deterministically at validation
+/// time rather than being silently ignored by a build that never
+/// constructs the adapter. Appliance-only *product policy* (single
+/// identity, required server name, HTTP/3 feature restrictions) lives in
+/// `validateApplianceTlsProfile`/`validateTlsServerNamePolicy` instead.
+fn validateNativeTlsBuildConfig(cfg: *const EdgeConfig) !void {
+    if (!is_native_tls_build) return;
+    if (!hasTlsFiles(cfg)) return;
+
+    if (!std.mem.eql(u8, cfg.tls_min_version, "1.3") or !std.mem.eql(u8, cfg.tls_max_version, "1.3")) {
+        logConfigDiagnostic("config validation failed: native-TLS builds are TLS 1.3-only; TARDIGRADE_TLS_MIN_VERSION and TARDIGRADE_TLS_MAX_VERSION must both be \"1.3\"", .{});
+        return error.UnsupportedNativeTlsConfiguration;
+    }
+    if (cfg.tls_cipher_list.len > 0 or cfg.tls_cipher_suites.len > 0) {
+        logConfigDiagnostic("config validation failed: native-TLS builds negotiate the built-in TLS 1.3 suite set; the OpenSSL-format TARDIGRADE_TLS_CIPHER_LIST/TARDIGRADE_TLS_CIPHER_SUITES overrides must be empty", .{});
+        return error.UnsupportedNativeTlsConfiguration;
+    }
+    if (cfg.tls_client_verify) {
+        logConfigDiagnostic("config validation failed: native-TLS builds do not support TARDIGRADE_TLS_CLIENT_VERIFY (downstream client certificate verification)", .{});
+        return error.UnsupportedNativeTlsConfiguration;
+    }
+    if (cfg.tls_session_cache_enabled) {
+        logConfigDiagnostic("config validation failed: native-TLS builds do not support TARDIGRADE_TLS_SESSION_CACHE (OpenSSL-terminator session cache); use TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE instead", .{});
+        return error.UnsupportedNativeTlsConfiguration;
+    }
+    if (cfg.tls_session_tickets_enabled) {
+        logConfigDiagnostic("config validation failed: native-TLS builds do not support TARDIGRADE_TLS_SESSION_TICKETS (OpenSSL-terminator tickets); use TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE instead", .{});
+        return error.UnsupportedNativeTlsConfiguration;
+    }
+    if (cfg.tls_ocsp_stapling_enabled) {
+        logConfigDiagnostic("config validation failed: native-TLS builds do not support TARDIGRADE_TLS_OCSP_STAPLING", .{});
+        return error.UnsupportedNativeTlsConfiguration;
+    }
+    if (cfg.tls_crl_check) {
+        logConfigDiagnostic("config validation failed: native-TLS builds do not support TARDIGRADE_TLS_CRL_CHECK", .{});
+        return error.UnsupportedNativeTlsConfiguration;
+    }
+    if (cfg.tls_acme_enabled) {
+        logConfigDiagnostic("config validation failed: native-TLS builds do not support TARDIGRADE_TLS_ACME_ENABLED (the ACME client is OpenSSL-adapter-only until its native implementation lands, #634)", .{});
+        return error.UnsupportedNativeTlsConfiguration;
+    }
+    if (cfg.tls_ocsp_auto_refresh) {
+        logConfigDiagnostic("config validation failed: native-TLS builds do not support TARDIGRADE_TLS_OCSP_AUTO_REFRESH", .{});
+        return error.UnsupportedNativeTlsConfiguration;
+    }
+    if (cfg.tls_dynamic_reload_interval_ms != 0) {
+        logConfigDiagnostic("config validation failed: native-TLS builds do not support TARDIGRADE_TLS_DYNAMIC_RELOAD_INTERVAL_MS (no filesystem credential watcher; rotate credentials via SIGHUP reload or restart)", .{});
+        return error.UnsupportedNativeTlsConfiguration;
+    }
+    if (cfg.proxy_protocol_mode != .off) {
+        logConfigDiagnostic("config validation failed: native-TLS builds do not support TARDIGRADE_PROXY_PROTOCOL; the native TLS path closes every connection before the handshake when a PROXY preface is expected", .{});
+        return error.UnsupportedNativeTlsConfiguration;
+    }
+}
+
 fn validateApplianceTlsProfile(cfg: *const EdgeConfig) !void {
     if (!is_appliance_tls_profile) return;
 
@@ -3007,53 +3075,6 @@ fn validateApplianceTlsProfile(cfg: *const EdgeConfig) !void {
     }
     if (cfg.http3_enabled and cfg.http3_retry_policy != .off) {
         logConfigDiagnostic("config validation failed: the appliance TLS profile does not support TARDIGRADE_HTTP3_RETRY_POLICY", .{});
-        return error.UnsupportedApplianceConfiguration;
-    }
-
-    if (!hasTlsFiles(cfg)) return;
-
-    if (!std.mem.eql(u8, cfg.tls_min_version, "1.3") or !std.mem.eql(u8, cfg.tls_max_version, "1.3")) {
-        logConfigDiagnostic("config validation failed: the appliance TLS profile is TLS 1.3-only; TARDIGRADE_TLS_MIN_VERSION and TARDIGRADE_TLS_MAX_VERSION must both be \"1.3\"", .{});
-        return error.UnsupportedApplianceConfiguration;
-    }
-    if (cfg.tls_cipher_list.len > 0 or cfg.tls_cipher_suites.len > 0) {
-        logConfigDiagnostic("config validation failed: the appliance TLS profile has a fixed cipher (TLS_AES_128_GCM_SHA256); TARDIGRADE_TLS_CIPHER_LIST/TARDIGRADE_TLS_CIPHER_SUITES must be empty", .{});
-        return error.UnsupportedApplianceConfiguration;
-    }
-    if (cfg.tls_client_verify) {
-        logConfigDiagnostic("config validation failed: the appliance TLS profile does not support TARDIGRADE_TLS_CLIENT_VERIFY (downstream client certificate verification)", .{});
-        return error.UnsupportedApplianceConfiguration;
-    }
-    if (cfg.tls_session_cache_enabled) {
-        logConfigDiagnostic("config validation failed: the appliance TLS profile does not support TARDIGRADE_TLS_SESSION_CACHE", .{});
-        return error.UnsupportedApplianceConfiguration;
-    }
-    if (cfg.tls_session_tickets_enabled) {
-        logConfigDiagnostic("config validation failed: the appliance TLS profile does not support TARDIGRADE_TLS_SESSION_TICKETS", .{});
-        return error.UnsupportedApplianceConfiguration;
-    }
-    if (cfg.tls_ocsp_stapling_enabled) {
-        logConfigDiagnostic("config validation failed: the appliance TLS profile does not support TARDIGRADE_TLS_OCSP_STAPLING", .{});
-        return error.UnsupportedApplianceConfiguration;
-    }
-    if (cfg.tls_crl_check) {
-        logConfigDiagnostic("config validation failed: the appliance TLS profile does not support TARDIGRADE_TLS_CRL_CHECK", .{});
-        return error.UnsupportedApplianceConfiguration;
-    }
-    if (cfg.tls_acme_enabled) {
-        logConfigDiagnostic("config validation failed: the appliance TLS profile does not support TARDIGRADE_TLS_ACME_ENABLED", .{});
-        return error.UnsupportedApplianceConfiguration;
-    }
-    if (cfg.tls_ocsp_auto_refresh) {
-        logConfigDiagnostic("config validation failed: the appliance TLS profile does not support TARDIGRADE_TLS_OCSP_AUTO_REFRESH", .{});
-        return error.UnsupportedApplianceConfiguration;
-    }
-    if (cfg.tls_dynamic_reload_interval_ms != 0) {
-        logConfigDiagnostic("config validation failed: the appliance TLS profile does not support TARDIGRADE_TLS_DYNAMIC_RELOAD_INTERVAL_MS (no filesystem credential watcher)", .{});
-        return error.UnsupportedApplianceConfiguration;
-    }
-    if (cfg.proxy_protocol_mode != .off) {
-        logConfigDiagnostic("config validation failed: the appliance TLS profile does not support TARDIGRADE_PROXY_PROTOCOL; the native TLS path closes every connection before the handshake when a PROXY preface is expected", .{});
         return error.UnsupportedApplianceConfiguration;
     }
 }
@@ -3103,6 +3124,7 @@ pub fn validate(cfg: *const EdgeConfig) !void {
         return error.InvalidConfigValue;
     };
     try validateTlsServerNamePolicy(cfg);
+    try validateNativeTlsBuildConfig(cfg);
     try validateApplianceTlsProfile(cfg);
     for (cfg.tls_sni_certs) |entry| {
         try validateOptionalFile(entry.cert_path, "tls_sni_cert.cert_path");
@@ -4223,16 +4245,17 @@ test "#368 Slice 3: parseEarlyDataReplayMaxEntriesConfig rejects malformed input
     try std.testing.expectEqual(tls_core.early_data_replay.hard_max_entries, try parseEarlyDataReplayMaxEntriesConfig("1048576"));
 }
 
-test "appliance profile defaults never trip validateApplianceTlsProfile" {
-    if (!is_appliance_tls_profile) return;
+test "native-TLS build defaults never trip the native or appliance validation gates" {
+    if (!is_native_tls_build) return;
     const allocator = std.testing.allocator;
     var cfg = try loadFromEnv(allocator);
     defer cfg.deinit(allocator);
+    try validateNativeTlsBuildConfig(&cfg);
     try validateApplianceTlsProfile(&cfg);
 }
 
-test "appliance profile rejects unsupported TLS settings one at a time" {
-    if (!is_appliance_tls_profile) return;
+test "native-TLS builds reject OpenSSL-adapter-only TLS settings one at a time" {
+    if (!is_native_tls_build) return;
     const allocator = std.testing.allocator;
 
     const cert_path = "tests/fixtures/tls/native_ed25519.crt";
@@ -4246,7 +4269,7 @@ test "appliance profile rejects unsupported TLS settings one at a time" {
     base.tls_key_path = try allocator.dupe(u8, key_path);
     allocator.free(base.tls_server_name);
     base.tls_server_name = try allocator.dupe(u8, "tardigrade.test");
-    try validateApplianceTlsProfile(&base);
+    try validateNativeTlsBuildConfig(&base);
 
     {
         // `cfg` is a shallow copy of `base` (aliasing its owned slices); do
@@ -4254,43 +4277,64 @@ test "appliance profile rejects unsupported TLS settings one at a time" {
         // `base.deinit` at the end of this test frees each allocation once.
         var cfg = base;
         cfg.tls_min_version = "1.2";
-        try std.testing.expectError(error.UnsupportedApplianceConfiguration, validateApplianceTlsProfile(&cfg));
+        try std.testing.expectError(error.UnsupportedNativeTlsConfiguration, validateNativeTlsBuildConfig(&cfg));
     }
     {
         var cfg = base;
         cfg.tls_cipher_list = "ECDHE-RSA-AES128-GCM-SHA256";
-        try std.testing.expectError(error.UnsupportedApplianceConfiguration, validateApplianceTlsProfile(&cfg));
+        try std.testing.expectError(error.UnsupportedNativeTlsConfiguration, validateNativeTlsBuildConfig(&cfg));
+    }
+    {
+        var cfg = base;
+        cfg.tls_cipher_suites = "TLS_AES_256_GCM_SHA384";
+        try std.testing.expectError(error.UnsupportedNativeTlsConfiguration, validateNativeTlsBuildConfig(&cfg));
     }
     {
         var cfg = base;
         cfg.tls_client_verify = true;
-        try std.testing.expectError(error.UnsupportedApplianceConfiguration, validateApplianceTlsProfile(&cfg));
+        try std.testing.expectError(error.UnsupportedNativeTlsConfiguration, validateNativeTlsBuildConfig(&cfg));
     }
     {
         var cfg = base;
         cfg.tls_session_cache_enabled = true;
-        try std.testing.expectError(error.UnsupportedApplianceConfiguration, validateApplianceTlsProfile(&cfg));
+        try std.testing.expectError(error.UnsupportedNativeTlsConfiguration, validateNativeTlsBuildConfig(&cfg));
     }
     {
         var cfg = base;
         cfg.tls_session_tickets_enabled = true;
-        try std.testing.expectError(error.UnsupportedApplianceConfiguration, validateApplianceTlsProfile(&cfg));
+        try std.testing.expectError(error.UnsupportedNativeTlsConfiguration, validateNativeTlsBuildConfig(&cfg));
     }
     {
         var cfg = base;
         cfg.tls_ocsp_stapling_enabled = true;
-        try std.testing.expectError(error.UnsupportedApplianceConfiguration, validateApplianceTlsProfile(&cfg));
+        try std.testing.expectError(error.UnsupportedNativeTlsConfiguration, validateNativeTlsBuildConfig(&cfg));
     }
     {
         var cfg = base;
         cfg.tls_crl_check = true;
-        try std.testing.expectError(error.UnsupportedApplianceConfiguration, validateApplianceTlsProfile(&cfg));
+        try std.testing.expectError(error.UnsupportedNativeTlsConfiguration, validateNativeTlsBuildConfig(&cfg));
     }
     {
         var cfg = base;
         cfg.tls_acme_enabled = true;
-        try std.testing.expectError(error.UnsupportedApplianceConfiguration, validateApplianceTlsProfile(&cfg));
+        try std.testing.expectError(error.UnsupportedNativeTlsConfiguration, validateNativeTlsBuildConfig(&cfg));
     }
+}
+
+test "appliance profile rejects unsupported HTTP/3 features one at a time" {
+    if (!is_appliance_tls_profile) return;
+    const allocator = std.testing.allocator;
+
+    var base = try loadFromEnv(allocator);
+    defer base.deinit(allocator);
+    allocator.free(base.tls_cert_path);
+    base.tls_cert_path = try allocator.dupe(u8, "tests/fixtures/tls/native_ed25519.crt");
+    allocator.free(base.tls_key_path);
+    base.tls_key_path = try allocator.dupe(u8, "tests/fixtures/tls/native_ed25519.key");
+    allocator.free(base.tls_server_name);
+    base.tls_server_name = try allocator.dupe(u8, "tardigrade.test");
+    try validateApplianceTlsProfile(&base);
+
     {
         var cfg = base;
         cfg.http3_enabled = true;
@@ -4332,8 +4376,8 @@ test "appliance profile rejects a configured server name with no credential file
     try std.testing.expectError(error.UnsupportedApplianceConfiguration, validateApplianceTlsProfile(&cfg));
 }
 
-test "appliance profile rejects PROXY protocol, credential watching, and OCSP auto-refresh with TLS active" {
-    if (!is_appliance_tls_profile) return;
+test "native-TLS builds reject PROXY protocol, credential watching, and OCSP auto-refresh with TLS active" {
+    if (!is_native_tls_build) return;
     const allocator = std.testing.allocator;
 
     var base = try loadFromEnv(allocator);
@@ -4344,22 +4388,22 @@ test "appliance profile rejects PROXY protocol, credential watching, and OCSP au
     base.tls_key_path = try allocator.dupe(u8, "tests/fixtures/tls/native_ed25519.key");
     allocator.free(base.tls_server_name);
     base.tls_server_name = try allocator.dupe(u8, "tardigrade.test");
-    try validateApplianceTlsProfile(&base);
+    try validateNativeTlsBuildConfig(&base);
 
     {
         var cfg = base;
         cfg.proxy_protocol_mode = .v1;
-        try std.testing.expectError(error.UnsupportedApplianceConfiguration, validateApplianceTlsProfile(&cfg));
+        try std.testing.expectError(error.UnsupportedNativeTlsConfiguration, validateNativeTlsBuildConfig(&cfg));
     }
     {
         var cfg = base;
         cfg.tls_dynamic_reload_interval_ms = 5000;
-        try std.testing.expectError(error.UnsupportedApplianceConfiguration, validateApplianceTlsProfile(&cfg));
+        try std.testing.expectError(error.UnsupportedNativeTlsConfiguration, validateNativeTlsBuildConfig(&cfg));
     }
     {
         var cfg = base;
         cfg.tls_ocsp_auto_refresh = true;
-        try std.testing.expectError(error.UnsupportedApplianceConfiguration, validateApplianceTlsProfile(&cfg));
+        try std.testing.expectError(error.UnsupportedNativeTlsConfiguration, validateNativeTlsBuildConfig(&cfg));
     }
 }
 

--- a/src/edge_config.zig
+++ b/src/edge_config.zig
@@ -3002,6 +3002,17 @@ fn validateTlsServerNamePolicy(cfg: *const EdgeConfig) !void {
 /// `validateApplianceTlsProfile`/`validateTlsServerNamePolicy` instead.
 fn validateNativeTlsBuildConfig(cfg: *const EdgeConfig) !void {
     if (!is_native_tls_build) return;
+
+    // ACME is checked before the TLS-files gate below: enabling ACME is a
+    // request to *obtain* credentials, so it is meaningful — and must fail
+    // deterministically — precisely when no cert/key pair is configured
+    // yet. Every check after the gate concerns behavior of an active local
+    // identity and is inert without one.
+    if (cfg.tls_acme_enabled) {
+        logConfigDiagnostic("config validation failed: native-TLS builds do not support TARDIGRADE_TLS_ACME_ENABLED (the ACME client is OpenSSL-adapter-only until its native implementation lands, #634)", .{});
+        return error.UnsupportedNativeTlsConfiguration;
+    }
+
     if (!hasTlsFiles(cfg)) return;
 
     if (!std.mem.eql(u8, cfg.tls_min_version, "1.3") or !std.mem.eql(u8, cfg.tls_max_version, "1.3")) {
@@ -3030,10 +3041,6 @@ fn validateNativeTlsBuildConfig(cfg: *const EdgeConfig) !void {
     }
     if (cfg.tls_crl_check) {
         logConfigDiagnostic("config validation failed: native-TLS builds do not support TARDIGRADE_TLS_CRL_CHECK", .{});
-        return error.UnsupportedNativeTlsConfiguration;
-    }
-    if (cfg.tls_acme_enabled) {
-        logConfigDiagnostic("config validation failed: native-TLS builds do not support TARDIGRADE_TLS_ACME_ENABLED (the ACME client is OpenSSL-adapter-only until its native implementation lands, #634)", .{});
         return error.UnsupportedNativeTlsConfiguration;
     }
     if (cfg.tls_ocsp_auto_refresh) {
@@ -4316,6 +4323,17 @@ test "native-TLS builds reject OpenSSL-adapter-only TLS settings one at a time" 
     }
     {
         var cfg = base;
+        cfg.tls_acme_enabled = true;
+        try std.testing.expectError(error.UnsupportedNativeTlsConfiguration, validateNativeTlsBuildConfig(&cfg));
+    }
+    {
+        // #641 review: ACME is a request to *obtain* credentials, so it
+        // must be rejected even when no cert/key pair is configured yet —
+        // it must not slip past the TLS-files early return and become
+        // silently inert.
+        var cfg = base;
+        cfg.tls_cert_path = "";
+        cfg.tls_key_path = "";
         cfg.tls_acme_enabled = true;
         try std.testing.expectError(error.UnsupportedNativeTlsConfiguration, validateNativeTlsBuildConfig(&cfg));
     }

--- a/src/gateway_shutdown.zig
+++ b/src/gateway_shutdown.zig
@@ -218,6 +218,35 @@ pub fn hotReloadConfig(
             return;
         }
     }
+    // #634 (#641 review): on the adapter-free profiles the native
+    // credential store and `native_tls_provider` are created only when TLS
+    // files exist at startup, and `startNewConnection` dispatches on that
+    // startup-fixed optional. A reload that turns TLS on for a process that
+    // started plaintext (or off for one that started with TLS) would
+    // therefore publish a config the runtime cannot honor — "reload
+    // applied" while new connections keep the old transport. Reject the
+    // topology change outright before any runtime mutation; enabling or
+    // disabling TLS is restart-owned on native builds. (On the appliance
+    // profile the credential-config check above already rejects these same
+    // transitions with its own message; this guard is the generic-native
+    // owner of the rule.)
+    if (edge_config.is_native_tls_build) {
+        var current_lease = worker_ctx.config_store.acquire();
+        const tls_topology_changed = edge_config.hasTlsFiles(current_lease.cfg) != edge_config.hasTlsFiles(cfg_ptr);
+        current_lease.release();
+        if (tls_topology_changed) {
+            worker_ctx.config_store.destroyVersion(prepared_version);
+            const msg = std.fmt.bufPrint(&state.last_reload_error, "enabling or disabling native TLS requires restart", .{}) catch "enabling or disabling native TLS requires restart";
+            state.reload_mutex.lock();
+            state.last_reload_ok = false;
+            state.last_reload_at_ms = now_ms;
+            state.last_reload_error_len = msg.len;
+            state.reload_mutex.unlock();
+            state.metricsRecordReloadFailure();
+            state.logger.warn(null, "config reload rejected: TARDIGRADE_TLS_CERT_PATH/TARDIGRADE_TLS_KEY_PATH would enable or disable TLS on a running native-TLS process; the native credential owner is startup-fixed, so restart to change TLS topology (#634)", .{});
+            return;
+        }
+    }
     // #629: a general-profile build serving both stable TCP (OpenSSL
     // `TlsTerminator`) and native HTTP/3 (`NativeCredentialStore`) has two
     // independent TLS credential owners. Left unrestricted, native H3 could

--- a/src/gateway_shutdown.zig
+++ b/src/gateway_shutdown.zig
@@ -613,15 +613,15 @@ test "#368 Slice 3: hotReloadConfig rejects a combined replay+protocol-policy re
     // pure `earlyDataReplayConfigChanged` comparator above, so it actually
     // proves the ordering, not just the comparator's logic.
     //
-    // Skipped under the appliance TLS profile (`-Dtls-profile=appliance`):
-    // that build swaps `http.tls_termination.TlsTerminator` for
-    // `tls_termination_stub.zig`, whose `init()` unconditionally returns
-    // `error.ContextInitFailed` — the appliance profile never constructs
-    // the generic OpenSSL terminator this test exercises, so there is
-    // nothing appliance-specific to prove here. `earlyDataReplayConfigChanged`
-    // above still covers the ordering-independent comparator logic in every
-    // profile.
-    if (edge_config.is_appliance_tls_profile) return;
+    // Skipped under the native-TLS profiles (`-Dtls-profile=appliance` and
+    // `-Dtls-profile=native`): those builds swap
+    // `http.tls_termination.TlsTerminator` for `tls_termination_stub.zig`,
+    // whose `init()` unconditionally returns `error.ContextInitFailed` —
+    // they never construct the generic OpenSSL terminator this test
+    // exercises, so there is nothing profile-specific to prove here.
+    // `earlyDataReplayConfigChanged` above still covers the
+    // ordering-independent comparator logic in every profile.
+    if (edge_config.is_native_tls_build) return;
     const allocator = std.testing.allocator;
 
     var current_cfg = try edge_config.loadFromEnv(allocator);

--- a/src/http/acme_backend.zig
+++ b/src/http/acme_backend.zig
@@ -1,10 +1,12 @@
-//! ACME client backend selector (#379, epic #327).
+//! ACME client backend selector (#379, epic #327, #634).
 //!
 //! Mirrors `tls_backend.zig`: `-Dtls-profile=general` selects the
-//! OpenSSL-backed ACME client, `-Dtls-profile=appliance` selects the
-//! no-OpenSSL stub, so an appliance binary never analyzes the ACME client's
-//! `@cImport("openssl/...")` and never links OpenSSL through the ACME path.
-//! The pure-Zig `ChallengeStore` is identical in both backends.
+//! OpenSSL-backed ACME client; the adapter-free profiles
+//! (`-Dtls-profile=appliance` and `-Dtls-profile=native`, i.e.
+//! `tls_openssl_adapter=false`) select the no-OpenSSL stub, so those
+//! binaries never analyze the ACME client's `@cImport("openssl/...")` and
+//! never link OpenSSL through the ACME path. The pure-Zig `ChallengeStore`
+//! is identical in both backends.
 
 const selected = if (@import("build_options").tls_openssl_adapter)
     @import("acme_client.zig")

--- a/src/http/tls_backend.zig
+++ b/src/http/tls_backend.zig
@@ -1,13 +1,16 @@
-//! TLS termination backend selector (#379, epic #327).
+//! TLS termination backend selector (#379, epic #327, #634).
 //!
 //! Every consumer of TLS termination — `http.zig`'s public alias and the
 //! direct importers inside `src/http/` — goes through this file, so exactly
 //! one backend type set exists per build. `-Dtls-profile=general` selects
-//! the approved OpenSSL adapter; `-Dtls-profile=appliance` selects the
-//! no-OpenSSL stub, in which case `tls_termination.zig` is never analyzed,
-//! `@cImport("openssl/...")` never runs, and no `libssl`/`libcrypto`
-//! linkage exists. The selection is a build-graph decision with no runtime
-//! fallback; see docs/TLS_DEPENDENCY_POLICY.md.
+//! the approved OpenSSL adapter; the adapter-free profiles
+//! (`-Dtls-profile=appliance` and `-Dtls-profile=native`, i.e.
+//! `tls_openssl_adapter=false`) select the no-OpenSSL stub, in which case
+//! `tls_termination.zig` is never analyzed, `@cImport("openssl/...")`
+//! never runs, and no `libssl`/`libcrypto` linkage exists — downstream TLS
+//! on those builds is served by `native_tls_connection.zig` instead. The
+//! selection is a build-graph decision with no runtime fallback; see
+//! docs/TLS_DEPENDENCY_POLICY.md.
 
 const selected = if (@import("build_options").tls_openssl_adapter)
     @import("tls_termination.zig")

--- a/src/http/tls_termination_stub.zig
+++ b/src/http/tls_termination_stub.zig
@@ -1,19 +1,23 @@
-//! No-OpenSSL TLS termination stub for the Bare Systems appliance profile
-//! (#379, epic #327).
+//! No-OpenSSL TLS termination stub for the adapter-free profiles
+//! (#379, epic #327, #634).
 //!
-//! Selected by `-Dtls-profile=appliance` in `src/http.zig`. Presents the
+//! Selected via `tls_backend.zig` whenever `tls_openssl_adapter` is false
+//! (`-Dtls-profile=appliance` and `-Dtls-profile=native`). Presents the
 //! same public surface as `tls_termination.zig` so every call site compiles
 //! unchanged, but contains no `@cImport`, no OpenSSL types, and no C
-//! linkage. Until the native TLS path lands (#391 defines the appliance
-//! support matrix), any attempt to construct a terminator or upstream TLS
-//! connection fails closed at startup with `error.ContextInitFailed` — a
-//! deliberate, inspectable failure rather than a hidden runtime fallback.
+//! linkage. Downstream TLS on those builds is served by the native
+//! listener (`native_tls_connection.zig`), never by this file; any attempt
+//! to construct the OpenSSL-shaped terminator or an upstream TLS
+//! connection (the OpenSSL-adapter-only paths) fails closed with
+//! `error.ContextInitFailed` — a deliberate, inspectable failure rather
+//! than a hidden runtime fallback.
 //!
 //! Option structs are duplicated field-for-field from the adapter so
-//! configuration parsing behaves identically in both profiles; only the
+//! configuration parsing behaves identically in every profile; only the
 //! I/O-bearing types are inert.
 
 const std = @import("std");
+const build_options = @import("build_options");
 const encrypted_stream = @import("tls_core").encrypted_stream;
 const negotiated_dispatch = @import("negotiated_dispatch.zig");
 
@@ -83,9 +87,14 @@ pub const NegotiatedProtocol = enum {
     http2,
 };
 
+// #641 review: this binary's own `-Dtls-profile` value, not a hardcoded
+// "appliance" — the `native` profile selects this same stub and must not
+// misreport itself as appliance in a handshake-error log line.
 const unavailable_message = "TLS termination is unavailable: this binary was built with " ++
-    "-Dtls-profile=appliance and contains no OpenSSL adapter; the native TLS " ++
-    "path is tracked by #391";
+    "-Dtls-profile=" ++ build_options.tls_profile ++ " and contains no OpenSSL adapter; " ++
+    "downstream TLS on this profile is served by the native listener " ++
+    "(native_tls_connection.zig), which this error path never reaches in " ++
+    "production — see #634";
 
 pub const TlsTerminator = struct {
     allocator: std.mem.Allocator,

--- a/src/main.zig
+++ b/src/main.zig
@@ -648,6 +648,7 @@ fn isConfigValidationError(err: anyerror) bool {
         error.InvalidCertificateChainOrder,
         error.CertificateSignatureInvalid,
         error.UnsupportedApplianceConfiguration,
+        error.UnsupportedNativeTlsConfiguration,
         => true,
         else => false,
     };

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -2944,6 +2944,17 @@ fn requireNativeTlsProfile() !void {
     if (build_options.tls_openssl_adapter) return error.SkipZigTest;
 }
 
+/// #634: cases asserting the Bare appliance *product policy* — the strict
+/// Ed25519 single-identity loader, `check`/startup credential preflight,
+/// unknown-SNI handshake rejection, restart-owned credential rotation —
+/// hold only on `-Dtls-profile=appliance`. The general-purpose `native`
+/// profile shares the adapter-free native TLS engine
+/// (`requireNativeTlsProfile` passes there too) but uses the permissive
+/// generic credential store, so these behaviors are intentionally absent.
+fn requireApplianceTlsProfile() !void {
+    if (!std.mem.eql(u8, build_options.tls_profile, "appliance")) return error.SkipZigTest;
+}
+
 /// #522: the appliance TLS profile explicitly forbids
 /// `TARDIGRADE_HTTP3_ENABLE_0RTT` (`edge_config.zig`'s
 /// `validateApplianceTlsProfile` rejects it outright as an unsupported
@@ -6408,8 +6419,8 @@ test "interop.openssl.sni_mismatch" {
     var tls_paths = try nativeTlsFixturePaths(allocator);
     defer tls_paths.deinit();
 
-    // The appliance TLS profile (the only profile the native listener builds
-    // under, see `requireNativeTlsProfile`) supports exactly one identity --
+    // The appliance TLS profile (the profile this suite runs under in CI,
+    // see `requireNativeTlsProfile`) supports exactly one identity --
     // `TARDIGRADE_TLS_SNI_CERTS` is rejected outright at startup. So "SNI
     // mismatch" here means the only meaningful, honest external case: a
     // client presenting any SNI other than the configured one, ticket or
@@ -8649,7 +8660,7 @@ test "rotation.persistent.n_to_n_plus_1" {
 //
 // This test does not additionally attempt to bundle a TLS credential change
 // into a failing SIGHUP: `requireNativeTlsProfile` gates every test in this
-// file to the appliance TLS profile build (the only profile where
+// file to the native-TLS builds (`-Dtls-profile=appliance`/`native`, where
 // `build_options.tls_openssl_adapter` is false), and inspecting
 // `edge_gateway.run`/`gateway_shutdown.hotReloadConfig` shows the appliance
 // profile's real served identity (`appliance_credentials.ApplianceCredentials`,
@@ -16788,6 +16799,7 @@ fn expectApplianceStartupFailure(
 }
 
 test "native TLS listener appliance identity serves the exact configured SNI" {
+    try requireApplianceTlsProfile();
     try requireNativeTlsProfile();
     const allocator = std.testing.allocator;
 
@@ -16827,6 +16839,28 @@ test "#488: native TLS listener resumes and serves HTTP traffic with production 
     var tls_paths = try nativeTlsFixturePaths(allocator);
     defer tls_paths.deinit();
 
+    // #634: this test's client handshakes with SNI "tardigrade.test". On
+    // the appliance profile the strict owner serves that name because it is
+    // the configured `TARDIGRADE_TLS_SERVER_NAME`; on the general-purpose
+    // `native` profile the generic credential store's default bundle only
+    // covers absent SNI (unknown names fail closed), so the same identity
+    // must be registered for the name explicitly via
+    // `TARDIGRADE_TLS_SNI_CERTS` — which the appliance profile in turn
+    // rejects outright, hence the per-profile env below.
+    const is_appliance = comptime std.mem.eql(u8, build_options.tls_profile, "appliance");
+    const sni_certs_value = try std.fmt.allocPrint(allocator, "tardigrade.test:{s}:{s}", .{ tls_paths.cert_path, tls_paths.key_path });
+    defer allocator.free(sni_certs_value);
+    const shared_env = [_]EnvPair{
+        .{ .name = "TARDIGRADE_TLS_CERT_PATH", .value = tls_paths.cert_path },
+        .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = tls_paths.key_path },
+        .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
+        .{ .name = "TARDIGRADE_HTTP2_ENABLED", .value = "false" },
+        .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE", .value = "stateful" },
+    };
+    var native_env: [shared_env.len + 1]EnvPair = undefined;
+    @memcpy(native_env[0..shared_env.len], &shared_env);
+    native_env[shared_env.len] = .{ .name = "TARDIGRADE_TLS_SNI_CERTS", .value = sni_certs_value };
+
     var tardigrade = try TardigradeProcess.start(allocator, .{
         .config_text =
         \\location = /healthz {
@@ -16835,13 +16869,7 @@ test "#488: native TLS listener resumes and serves HTTP traffic with production 
         ,
         .ready_https_insecure = true,
         .ready_path = "/healthz",
-        .extra_env = &.{
-            .{ .name = "TARDIGRADE_TLS_CERT_PATH", .value = tls_paths.cert_path },
-            .{ .name = "TARDIGRADE_TLS_KEY_PATH", .value = tls_paths.key_path },
-            .{ .name = "TARDIGRADE_TLS_SERVER_NAME", .value = "tardigrade.test" },
-            .{ .name = "TARDIGRADE_HTTP2_ENABLED", .value = "false" },
-            .{ .name = "TARDIGRADE_TLS_NATIVE_RESUMPTION_MODE", .value = "stateful" },
-        },
+        .extra_env = if (is_appliance) &shared_env else &native_env,
     });
     defer tardigrade.stop();
 
@@ -16952,6 +16980,7 @@ test "#488: native TLS listener resumes and serves HTTP traffic with production 
 }
 
 test "native TLS listener appliance rejects unknown SNI before HTTP dispatch" {
+    try requireApplianceTlsProfile();
     try requireNativeTlsProfile();
     const allocator = std.testing.allocator;
 
@@ -17004,18 +17033,21 @@ test "native TLS listener appliance rejects unknown SNI before HTTP dispatch" {
 }
 
 test "native TLS listener appliance refuses startup with a mismatched key" {
+    try requireApplianceTlsProfile();
     try requireNativeTlsProfile();
     const allocator = std.testing.allocator;
     try expectApplianceStartupFailure(allocator, "native_ed25519_mismatch.key", "error.KeyCertificateMismatch");
 }
 
 test "native TLS listener appliance refuses startup with an unsupported key algorithm" {
+    try requireApplianceTlsProfile();
     try requireNativeTlsProfile();
     const allocator = std.testing.allocator;
     try expectApplianceStartupFailure(allocator, "native_p256.key", "error.UnsupportedPrivateKeyAlgorithm");
 }
 
 test "appliance run --daemon rejects a mismatched key synchronously, without ever backgrounding" {
+    try requireApplianceTlsProfile();
     try requireNativeTlsProfile();
     const allocator = std.testing.allocator;
 
@@ -17073,6 +17105,7 @@ test "appliance run --daemon rejects a mismatched key synchronously, without eve
 }
 
 test "appliance master mode rejects a mismatched key before writing a PID file or spawning workers" {
+    try requireApplianceTlsProfile();
     try requireNativeTlsProfile();
     const allocator = std.testing.allocator;
 
@@ -17131,6 +17164,7 @@ test "appliance master mode rejects a mismatched key before writing a PID file o
 }
 
 test "native TLS listener appliance check command validates credentials without binding" {
+    try requireApplianceTlsProfile();
     try requireNativeTlsProfile();
     const allocator = std.testing.allocator;
 
@@ -17204,6 +17238,7 @@ test "native TLS listener appliance check command validates credentials without 
 }
 
 test "appliance hot reload rejects turning TLS on for a server that started plaintext" {
+    try requireApplianceTlsProfile();
     try requireNativeTlsProfile();
     const allocator = std.testing.allocator;
 
@@ -17271,6 +17306,7 @@ test "appliance hot reload rejects turning TLS on for a server that started plai
 }
 
 test "appliance hot reload rejects turning TLS off for a server that started with TLS" {
+    try requireApplianceTlsProfile();
     try requireNativeTlsProfile();
     const allocator = std.testing.allocator;
 

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -2955,6 +2955,16 @@ fn requireApplianceTlsProfile() !void {
     if (!std.mem.eql(u8, build_options.tls_profile, "appliance")) return error.SkipZigTest;
 }
 
+/// #634: the general-purpose adapter-free profile (`-Dtls-profile=native`)
+/// only — for cases proving generic-native behavior whose appliance
+/// counterpart takes a different code path with its own assertions (e.g.
+/// the appliance credential-config reload rejection vs. the generic
+/// native TLS-topology reload rejection).
+fn requireGenericNativeTlsProfile() !void {
+    try requireNativeTlsProfile();
+    if (std.mem.eql(u8, build_options.tls_profile, "appliance")) return error.SkipZigTest;
+}
+
 /// #522: the appliance TLS profile explicitly forbids
 /// `TARDIGRADE_HTTP3_ENABLE_0RTT` (`edge_config.zig`'s
 /// `validateApplianceTlsProfile` rejects it outright as an unsupported
@@ -17237,6 +17247,39 @@ test "native TLS listener appliance check command validates credentials without 
     try std.testing.expectEqual(std.process.Child.Term{ .exited = 2 }, unnamed.term);
 }
 
+test "native TLS listener check rejects ACME on native builds even without credentials" {
+    try requireNativeTlsProfile();
+    const allocator = std.testing.allocator;
+
+    // #634 (#641 review): enabling ACME is a request to *obtain*
+    // credentials, so the native capability gate must reject it through the
+    // real `tardi check` path even when no cert/key pair is configured —
+    // it must not become silently inert behind the TLS-files gate.
+    const config_rel = try std.fmt.allocPrint(allocator, ".zig-cache/tardigrade-native-acme-check-{d}.conf", .{compat.nanoTimestamp()});
+    defer {
+        compat.cwd().deleteFile(config_rel) catch {};
+        allocator.free(config_rel);
+    }
+    try compat.cwd().writeFile(.{ .sub_path = config_rel, .data = "" });
+
+    var env_map = try inheritedEnvMap(allocator);
+    defer env_map.deinit();
+    try env_map.put("TARDIGRADE_TLS_ACME_ENABLED", "true");
+    _ = env_map.swapRemove("TARDIGRADE_TLS_CERT_PATH");
+    _ = env_map.swapRemove("TARDIGRADE_TLS_KEY_PATH");
+
+    const result = try std.process.run(allocator, compat.io(), .{
+        .argv = &.{ integration_options.tardigrade_bin_path, "check", config_rel },
+        .environ_map = &env_map,
+        .stdout_limit = .limited(64 * 1024),
+        .stderr_limit = .limited(64 * 1024),
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+    try std.testing.expectEqual(std.process.Child.Term{ .exited = 2 }, result.term);
+    try assertContains(result.stderr, "TARDIGRADE_TLS_ACME_ENABLED");
+}
+
 test "appliance hot reload rejects turning TLS on for a server that started plaintext" {
     try requireApplianceTlsProfile();
     try requireNativeTlsProfile();
@@ -17365,6 +17408,143 @@ test "appliance hot reload rejects turning TLS off for a server that started wit
     // The TLS listener is still there and still authenticates with the
     // original identity.
     const second_client = try PureZigTlsClient.createWithServerName(allocator, tardigrade.port, "http/1.1", "tardigrade.test");
+    defer second_client.destroy();
+    try second_client.writeAllPlain("GET /healthz HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n");
+    const after = try second_client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+    defer allocator.free(after);
+    try std.testing.expectEqual(@as(usize, 1), countOccurrences(after, "HTTP/1.1 200 OK"));
+    try assertContains(after, "alive");
+}
+
+// #634 (#641 review): the generic-native counterparts of the two appliance
+// reload-rejection tests above. On `-Dtls-profile=native` the credential
+// store/provider are created only when TLS files exist at startup and
+// `startNewConnection` dispatches on that startup-fixed optional, so a
+// reload that changes TLS topology must be rejected outright — never
+// "reload applied" while new connections keep the old transport. The
+// appliance profile rejects the same transitions through its own
+// credential-config check with a different message, asserted by the tests
+// above; these two are skipped there.
+
+test "native TLS listener generic-native hot reload rejects turning TLS on for a server that started plaintext" {
+    try requireGenericNativeTlsProfile();
+    const allocator = std.testing.allocator;
+
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text =
+        \\location = /healthz {
+        \\    return 200 alive;
+        \\}
+        ,
+        // No TLS env at all: the process starts in plaintext, so neither
+        // the NativeCredentialStore nor native_tls_provider is constructed.
+    });
+    defer tardigrade.stop();
+
+    var before = try sendRequest(allocator, tardigrade.port, .{
+        .method = "GET",
+        .path = "/healthz",
+        .body = null,
+        .headers = &.{},
+    });
+    defer before.deinit();
+    try std.testing.expectEqual(@as(u16, 200), before.status_code);
+    try assertContains(before.body, "alive");
+
+    // Rewrite the config file to turn TLS on with a valid identity, then
+    // reload. The reload must be rejected (there is no credential store to
+    // populate on a running WorkerContext) rather than publishing a
+    // TLS-marked config while new connections silently continue over
+    // plaintext.
+    var tls_paths = try nativeTlsFixturePaths(allocator);
+    defer tls_paths.deinit();
+    const updated_config = try std.fmt.allocPrint(allocator,
+        \\location = /healthz {{
+        \\    return 200 alive;
+        \\}}
+        \\tls_cert_path {s};
+        \\tls_key_path {s};
+    , .{ tls_paths.cert_path, tls_paths.key_path });
+    defer allocator.free(updated_config);
+    try tardigrade.rewriteConfig(updated_config);
+    tardigrade.sendSignal(std.posix.SIG.HUP);
+
+    try waitForLogSubstring(
+        allocator,
+        tardigrade.log_path,
+        "would enable or disable TLS on a running native-TLS process",
+        3_000,
+    );
+
+    // New connections still succeed over plain HTTP: the reload never took
+    // effect, so the listener's behavior is unchanged.
+    var after = try sendRequest(allocator, tardigrade.port, .{
+        .method = "GET",
+        .path = "/healthz",
+        .body = null,
+        .headers = &.{},
+    });
+    defer after.deinit();
+    try std.testing.expectEqual(@as(u16, 200), after.status_code);
+    try assertContains(after.body, "alive");
+}
+
+test "native TLS listener generic-native hot reload rejects turning TLS off for a server that started with TLS" {
+    try requireGenericNativeTlsProfile();
+    const allocator = std.testing.allocator;
+
+    var tls_paths = try nativeTlsFixturePaths(allocator);
+    defer tls_paths.deinit();
+
+    // The identity is configured entirely through config-file directives
+    // (no TARDIGRADE_TLS_* env vars) so that editing the file and sending
+    // SIGHUP is a genuine topology change, not shadowed by env — same
+    // reasoning as the appliance variant above.
+    const initial_config = try std.fmt.allocPrint(allocator,
+        \\location = /healthz {{
+        \\    return 200 alive;
+        \\}}
+        \\tls_cert_path {s};
+        \\tls_key_path {s};
+    , .{ tls_paths.cert_path, tls_paths.key_path });
+    defer allocator.free(initial_config);
+
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = initial_config,
+        .ready_https_insecure = true,
+        .ready_path = "/healthz",
+    });
+    defer tardigrade.stop();
+
+    // Absent SNI selects the generic store's default identity.
+    const client = try PureZigTlsClient.createWithServerName(allocator, tardigrade.port, "http/1.1", null);
+    defer client.destroy();
+    try client.writeAllPlain("GET /healthz HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n");
+    const before = try client.readPlainToEnd(allocator, 64 * 1024, 5_000);
+    defer allocator.free(before);
+    try std.testing.expectEqual(@as(usize, 1), countOccurrences(before, "HTTP/1.1 200 OK"));
+    try assertContains(before, "alive");
+
+    // Rewrite the config file dropping every TLS directive, then reload.
+    // This must be rejected — the running provider and identity stay active.
+    const updated_config =
+        \\location = /healthz {
+        \\    return 200 alive;
+        \\}
+    ;
+    try tardigrade.rewriteConfig(updated_config);
+    tardigrade.sendSignal(std.posix.SIG.HUP);
+
+    try waitForLogSubstring(
+        allocator,
+        tardigrade.log_path,
+        "would enable or disable TLS on a running native-TLS process",
+        3_000,
+    );
+
+    // The TLS listener is still there and still serves with the original
+    // identity.
+    const second_client = try PureZigTlsClient.createWithServerName(allocator, tardigrade.port, "http/1.1", null);
     defer second_client.destroy();
     try second_client.writeAllPlain("GET /healthz HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n");
     const after = try second_client.readPlainToEnd(allocator, 64 * 1024, 5_000);


### PR DESCRIPTION
## Summary

First build-composition slice of #634 (native pure-Zig as the sole shipping implementation). Adds the general-purpose native profile the architecture calls for, without touching the default build or release artifacts.

- **New `-Dtls-profile=native`**: adapter-free general-purpose build — native TCP TLS termination, native QUIC/H3, generic multi-identity credential store with SNI certs, SIGHUP credential hot-reload, opt-in native resumption. No `libssl`/`libcrypto` linkage; `tardi version` reports `tls-profile=native, tls-backend=native`. This activates the generic-native composition `edge_gateway` already carried but no profile could previously select.
- **Validation restructured per #634's "profiles are policy, not backend" rule**: the OpenSSL-adapter-only capability checks (TLS 1.2, cipher-string overrides, mTLS, OpenSSL session cache/tickets, OCSP stapling/refresh, CRL, ACME, filesystem credential watcher, PROXY protocol with TLS) move from `validateApplianceTlsProfile` into a shared `validateNativeTlsBuildConfig` gate that fails deterministically (`error.UnsupportedNativeTlsConfiguration`) on both native profiles. Appliance-only product policy (single Ed25519 identity, server-name coupling, H3 0-RTT/migration/Retry restrictions) stays appliance-only. Profile-conditioned defaults now key on the native build.
- **Enforcement**: `scripts/audit-release-binary.sh` accepts `--profile native` (no foreign linkage, must self-report the native backend); CI's dependency-audit job builds and binary-audits the native artifact on every change.
- **Tests**: new `requireApplianceTlsProfile` gate for appliance product-policy integration cases; the #488 resumption case now runs under both native profiles (on `native` it registers its SNI name via `TARDIGRADE_TLS_SNI_CERTS`, since the generic store fail-closes unknown SNI — the same behavior native H3 already has in the general profile).
- **Docs**: `TLS_DEPENDENCY_POLICY.md` reframed around the #634 architecture (native-only shipping, general/OpenSSL explicitly transitional, updated cutover checklist); `CONFIGURATION.md`, `TROUBLESHOOTING.md`, `RELOAD_SHUTDOWN.md`, `BARE_APPLIANCE_TLS.md`, and `tardi explain` reference updated to the appliance/native split.

Out of scope (later #634 slices): flipping the default profile, release/packaging/Docker/Homebrew cutover, native ACME/mTLS/OCSP parity, default-identity SAN matching for SNI.

## Test plan

- [x] `zig build test` passes under `general`, `native`, and `appliance` profiles
- [x] `zig build test-integration-native-tls` passes under both `appliance` and `native` profiles (appliance-policy cases skip on `native` by design)
- [x] `scripts/audit-dependencies.sh` passes; `scripts/audit-release-binary.sh --profile native` passes against the built artifact (only `libSystem` linked on Darwin)
- [x] Live smoke of the native-profile binary: TLS 1.3 handshake with an independent OpenSSL client (P-256 identity, ALPN h2/http1.1 dispatch, static file served over H1); Ed25519 identity served when the client offers the ed25519 signature scheme
- [x] Deterministic rejection verified: `tardi check` fails with the native-TLS message for `TARDIGRADE_TLS_ACME_ENABLED=true` on a native build

Part of #634 (do **not** auto-close; the cutover has remaining distribution slices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)