### PR TITLE
packaging: cut Docker and standalone DEB/RPM tooling over to native-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1523,6 +1523,19 @@ All notable user-facing changes to Tardigrade are documented here.
   `tls-backend=openssl-adapter` string no longer exists). OpenSSL remains
   available only out of process, as an interoperability/differential-testing
   oracle.
+- **OpenSSL from the local Docker image and standalone DEB/RPM packaging
+  (#650)** — the root `Dockerfile` no longer installs `libssl-dev` in the
+  build stage or `libssl3` in the runtime stage; `scripts/test-docker-image.sh`
+  now extracts the exact runtime binary and audits it with
+  `scripts/audit-release-binary.sh` instead of inferring composition from
+  Dockerfile text. `packaging/deb/build.sh` and `packaging/rpm/build.sh` no
+  longer accept `--tls-backend native|openssl-adapter`; every produced
+  package's native identity is proven with `scripts/audit-release-binary.sh`
+  (self-audited for a host-executable binary, or via a new SHA-256-bound
+  `--audit-inventory` file for cross-architecture packaging) instead of a
+  caller-supplied backend flag, and no package declares an OpenSSL runtime
+  dependency any more — the RPM spec's conditional `Requires: openssl-libs`
+  is removed outright.
 
 ## [0.5.0] - 2026-07-08
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM debian@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        ca-certificates curl xz-utils libssl-dev \
+        ca-certificates curl xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src
@@ -17,8 +17,8 @@ COPY . .
 RUN sh ./scripts/install-zig.sh 0.16.0 /opt/zig \
     && ln -s "$(find /opt/zig -maxdepth 3 -type f -name zig)" /usr/local/bin/zig
 
-# Default "general" TLS profile: links the approved OpenSSL adapter (see
-# docs/TLS_DEPENDENCY_POLICY.md). Requires libssl-dev above.
+# Default "general" TLS profile: pure-Zig native (#649) — no OpenSSL/libcrypto
+# build dependency for Tardigrade itself (see docs/TLS_DEPENDENCY_POLICY.md).
 RUN zig build -Doptimize=ReleaseFast
 
 # ── Runtime ───────────────────────────────────────────────────────────────────
@@ -33,7 +33,7 @@ ARG TARDIGRADE_UID=10001
 ARG TARDIGRADE_GID=10001
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates libssl3 \
+    && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --system --gid "$TARDIGRADE_GID" tardigrade \
     && useradd --system --uid "$TARDIGRADE_UID" --gid "$TARDIGRADE_GID" \

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -308,9 +308,13 @@ pinned Zig toolchain (matching `.github/workflows/ci.yml`) and the default
 build or run `tardi` itself (see
 [TLS_DEPENDENCY_POLICY.md](TLS_DEPENDENCY_POLICY.md)); the runtime stage
 contains only `tardi`, CA-certificate data, and a non-root `tardigrade`
-user. No Zig toolchain or source tree ships in the final image. The
-Dockerfile's own OpenSSL package installs predate #649 and are tracked as
-distribution cleanup separately from this cutover (#634).
+user. Neither stage installs `libssl-dev`/`libssl3` or any other foreign
+TLS/crypto library for Tardigrade (#650); `ca-certificates` remains in the
+runtime image as ordinary OS trust-store substrate, not a Tardigrade
+implementation dependency. No Zig toolchain or source tree ships in the
+final image. `scripts/test-docker-image.sh` extracts the exact runtime
+binary and audits it with `scripts/audit-release-binary.sh` rather than
+inferring native-only composition from the Dockerfile text alone.
 
 ### Build
 

--- a/docs/TLS_DEPENDENCY_POLICY.md
+++ b/docs/TLS_DEPENDENCY_POLICY.md
@@ -227,8 +227,13 @@ on macOS) and emits a machine-readable JSON inventory. It fails if:
 - an artifact's self-reported `tls-profile` disagrees with the profile it
   was built and audited as.
 
-The inventory records the binary, profile, host OS, inspection tool,
-self-reported backend, full dependency list, and any violations.
+The inventory records the binary, its SHA-256 checksum, profile, host OS,
+inspection tool, self-reported backend, full dependency list, and any
+violations. The checksum lets a consumer that cannot execute the binary
+itself — e.g. the standalone DEB/RPM builders packaging a cross-architecture
+artifact (`packaging/deb/build.sh`, `packaging/rpm/build.sh`) — bind an
+already-produced inventory to the exact artifact instead of trusting a
+caller-supplied backend flag.
 
 ### CI
 
@@ -257,9 +262,19 @@ release assets and SBOM.
 - **#645**/**#646** extended the native certificate-signature matrix and
   raised handshake size bounds so the native upstream client is usable
   against ordinary public-WebPKI origins.
-- **#649** (this cutover) made native the default and *only* selectable
-  production implementation: retired the OpenSSL adapter, `configureSsl`,
-  the `general`/`native` profile distinction (merged into a single native
+- **#649** made native the default and *only* selectable production
+  implementation: retired the OpenSSL adapter, `configureSsl`, the
+  `general`/`native` profile distinction (merged into a single native
   `general` tag), and every OpenSSL production source surface. #634 stays
   open for the distribution/packaging and final-release-proof work it also
   covers, which #649 does not.
+- **#650** finished the local/package/container distribution cutover left
+  open by #649: the root `Dockerfile` no longer installs `libssl-dev` or
+  `libssl3` for Tardigrade, its runtime binary is audited directly with
+  `scripts/audit-release-binary.sh` rather than inferred from Dockerfile
+  text, and the standalone `packaging/deb/build.sh`/`packaging/rpm/build.sh`
+  builders no longer accept `--tls-backend openssl-adapter` or emit an
+  OpenSSL runtime dependency — the packaged artifact's native identity is
+  always proven by the same audit script (self-audited for a host-executable
+  binary, or via a SHA-256-bound `--audit-inventory` file for
+  cross-architecture packaging) instead of a caller-supplied backend flag.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -11,12 +11,12 @@ versus what is a local-build-only tool.
 | --- | --- | --- |
 | Linux release archives (`.tar.gz`, x86_64/aarch64) | **Supported, published** | Built and attached to every GitHub release by `.github/workflows/release.yml`, alongside `install.sh`, `tardigrade-checksums.txt`, per-arch SPDX SBOMs, dependency inventories, and provenance. Releases containing #476 build these official artifacts with the default `-Dtls-profile=general` (pure-Zig native since #649); older already-published releases may predate that cutover. |
 | macOS release archives (`.tar.gz`, darwin x86_64/arm64) | **Implemented in #476; awaiting first release** | #476 adds `macos-15-intel` and `macos-15` release rows for `tardigrade-darwin-x86_64.tar.gz` and `tardigrade-darwin-arm64.tar.gz`, using the same archive/SBOM/inventory/provenance pipeline as Linux. Both rows build with the default `-Dtls-profile=general` (pure-Zig native since #649) without Homebrew OpenSSL, audit out foreign TLS/crypto/QUIC/H3 linkage, assert the Mach-O architecture, package/extract the archive, verify native build identity, run a real static-site startup/request smoke from the extracted artifact, and exercise the checksum-verifying installer path. The currently published latest release still predates #476, so these assets are not public until the first intentional release containing it. |
-| DEB (`packaging/deb/build.sh`) | **Supported, published** | Built for `amd64`/`arm64` from the same release binaries as the `.tar.gz` archives and attached to every GitHub release; also usable as a local builder. Host-native builds infer dependency metadata from `tardi version`; cross-compiled binaries can declare `--tls-backend native|openssl-adapter` explicitly. Native binaries declare no OpenSSL runtime dependency, while a transitional local `general`/OpenSSL binary still gets the dependency it actually needs. |
-| RPM (`packaging/rpm/build.sh`) | **Supported, published** | Same treatment as DEB, for `x86_64`/`aarch64`. Host-native builds infer the backend and cross-compiled builds can pass it explicitly. The spec's OpenSSL runtime dependency is conditional on the packaged binary/backend; official native release packages do not declare it. Built from the same Ubuntu-runner binary as the archives — see the glibc compatibility note below if targeting an older RHEL-family release. |
+| DEB (`packaging/deb/build.sh`) | **Supported, published** | Built for `amd64`/`arm64` from the same release binaries as the `.tar.gz` archives and attached to every GitHub release; also usable as a local builder. The packaged binary's native identity is always proven with `scripts/audit-release-binary.sh` — self-audited when the binary is host-executable, or via a SHA-256-bound `--audit-inventory` file for cross-architecture packaging — never by a caller-supplied backend flag (#650). Every package declares no OpenSSL runtime dependency; there is no other production backend to package. |
+| RPM (`packaging/rpm/build.sh`) | **Supported, published** | Same treatment as DEB, for `x86_64`/`aarch64`, including the native-identity audit and no OpenSSL runtime dependency (#650). Built from the same Ubuntu-runner binary as the archives — see the glibc compatibility note below if targeting an older RHEL-family release. |
 | systemd unit (`packaging/systemd/tardigrade.service`) | **Supported** | Installed and structurally validated (unit file text/layout, permissions) by both the DEB and RPM smoke tests. Neither test boots systemd or exercises a real start/status/reload/stop lifecycle — see [docs/DEPLOYMENT.md](../docs/DEPLOYMENT.md#the-systemd-units-pidcontrol-path-contract) for the unit contract these assertions check. |
 | launchd plist (`packaging/launchd/io.baresystems.tardigrade.plist`) | **CI-validated user LaunchAgent template** | The Darwin release-smoke workflow renders the checked-in host-style `/usr/local/...` template into an isolated prefix on the `macos-15` Apple Silicon runner, stages the native Darwin archive's `tardi` binary plus `tardigrade -> tardi` compatibility alias, and proves a real `launchctl bootstrap` -> readiness/request -> `bootout` lifecycle in the current user's launchd domain. |
-| Homebrew (`packaging/homebrew/tardigrade.rb`) | **Preparatory; awaiting native release** | `scripts/update-homebrew-formula.sh` renders the formula from one release tag and verifies the referenced archives exist in that same release. The current public `v0.5.0` release predates the native #634 shipping cutover and old/new archive-layout switch, so it must not be used for the public tap formula. Generate and publish the tap formula only after a release publishes native audited archives with canonical `tardi` plus the `tardigrade` alias. |
-| Docker / OCI image | **Local build supported, not published** | Root [`Dockerfile`](../Dockerfile) and [`compose.yaml`](../compose.yaml) build a runtime image locally; smoke-tested via `scripts/test-docker-image.sh` in the `packaging-smoke` CI job. No registry-published image or container-publishing workflow exists. Docker's remaining OpenSSL cutover is tracked by #634 and is separate from the raw release/archive lane in #476. See [docs/DEPLOYMENT.md](../docs/DEPLOYMENT.md) for the full workflow. |
+| Homebrew (`packaging/homebrew/tardigrade.rb`) | **Preparatory; awaiting native release** | `scripts/update-homebrew-formula.sh` renders the formula from one release tag and verifies the referenced archives exist in that same release. The current public `v0.5.0` release predates the native #634 shipping cutover and old/new archive-layout switch, so it must not be used for the public tap formula. Generate and publish the tap formula only after a release publishes native audited archives with canonical `tardi` plus the `tardigrade` alias. #466, not this document, owns the public tap. |
+| Docker / OCI image | **Local build supported, not published** | Root [`Dockerfile`](../Dockerfile) and [`compose.yaml`](../compose.yaml) build a runtime image locally; smoke-tested via `scripts/test-docker-image.sh` in the `packaging-smoke` CI job, which extracts the exact runtime binary and audits it with `scripts/audit-release-binary.sh` rather than trusting the Dockerfile text. Neither build stage installs OpenSSL/libcrypto for Tardigrade (#650). No registry-published image or container-publishing workflow exists. See [docs/DEPLOYMENT.md](../docs/DEPLOYMENT.md) for the full workflow. |
 
 ## Official release implementation
 
@@ -28,17 +28,22 @@ zig build -Doptimize=ReleaseFast -Dversion=<version>
 ```
 
 The release workflow audits each produced binary with
-`scripts/audit-release-binary.sh --profile native`. That audit fails if the
+`scripts/audit-release-binary.sh --profile general`. That audit fails if the
 artifact links `libssl`, `libcrypto`, or another forbidden foreign
 TLS/crypto/QUIC/H3 implementation and verifies that `tardi version` reports
-`tls-profile=native, tls-backend=native`.
+`tls-profile=general, tls-backend=native`.
 
-Linux DEB/RPM packages are built from that same audited host-native binary. The
-package builders infer its backend from `tardi version`, and the release job then
+Linux DEB/RPM packages are built from that same audited host-native binary.
+`packaging/deb/build.sh`/`packaging/rpm/build.sh` self-audit the binary with
+`scripts/audit-release-binary.sh` (rather than inferring its backend from
+`tardi version` or trusting a caller-supplied flag), and the release job then
 inspects the resulting package metadata and fails if either native package
-declares an OpenSSL/libssl/libcrypto runtime dependency. Local cross-compiled
-packages can provide `--tls-backend native|openssl-adapter` explicitly when the
-target binary cannot execute on the packaging host.
+declares an OpenSSL/libssl/libcrypto runtime dependency. Local
+cross-architecture packages — where the target binary cannot execute on the
+packaging host — provide `--audit-inventory` with a
+`scripts/audit-release-binary.sh --output` inventory already generated for
+that exact binary (matched by SHA-256) instead of asserting a backend
+directly.
 
 ## Quick install (recommended)
 
@@ -104,12 +109,10 @@ the native profile for a shipping-equivalent package:
 # 1. Build the binary first (cross-compile for the target arch as needed)
 zig build -Doptimize=ReleaseFast
 
-# 2. Build the DEB. Passing the backend explicitly also works when the target
-#    binary is for a different architecture than the packaging host.
+# 2. Build the DEB.
 ./packaging/deb/build.sh \
   --version 0.50 \
-  --arch amd64 \
-  --tls-backend native
+  --arch amd64
 
 # Output: dist/tardigrade_0.50_amd64.deb
 ```
@@ -120,13 +123,29 @@ sudo apt install ./dist/tardigrade_0.50_amd64.deb
 sudo systemctl enable --now tardigrade
 ```
 
-When `--tls-backend` is omitted, the DEB builder infers it from an executable
-host-native binary's `tardi version` output. Native binaries have no OpenSSL
-package dependency; a transitional local binary reporting
-`tls-backend=openssl-adapter` gets `Depends: libssl3 | libssl1.1`. Unknown
-backends fail rather than generating ambiguous dependency metadata. For a
-foreign-architecture binary, pass `--tls-backend native` or
-`--tls-backend openssl-adapter` explicitly.
+The DEB builder always proves the packaged binary is Tardigrade's sole native
+production implementation with `scripts/audit-release-binary.sh` — it never
+trusts a caller-supplied backend flag. When `--binary` is executable on the
+packaging host, the builder self-audits it directly. For a foreign-architecture
+binary that cannot run on the packaging host, generate an inventory for it
+first (e.g. on the target architecture, or under emulation) and pass it in:
+
+```bash
+./scripts/audit-release-binary.sh \
+  --binary path/to/foreign-arch/tardi \
+  --profile general \
+  --output /tmp/tardi-inventory.json
+
+./packaging/deb/build.sh \
+  --version 0.50 \
+  --arch arm64 \
+  --binary path/to/foreign-arch/tardi \
+  --audit-inventory /tmp/tardi-inventory.json
+```
+
+The inventory is matched to `--binary` by SHA-256, so it must have been
+generated for that exact artifact. Every produced package has no OpenSSL
+package dependency; there is no other production backend to package.
 
 The DEB package:
 - Installs the binary to `/usr/bin/tardi`
@@ -171,16 +190,14 @@ identically to `dnf install` for a local file.
 
 ```bash
 # 1. Install prerequisites
-dnf install rpm-build
+dnf install rpm-build jq
 
 # 2. Build the binary
 zig build -Doptimize=ReleaseFast
 
-# 3. Build the RPM. Passing the backend explicitly also works for a
-#    foreign-architecture binary.
+# 3. Build the RPM.
 ./packaging/rpm/build.sh \
-  --version 0.50 \
-  --tls-backend native
+  --version 0.50
 
 # Output: dist/tardigrade-0.50-1.x86_64.rpm
 ```
@@ -191,10 +208,12 @@ sudo rpm -i dist/tardigrade-0.50-1.x86_64.rpm
 sudo systemctl enable --now tardigrade
 ```
 
-Like the DEB builder, the RPM builder auto-detects the backend for executable
-host-native binaries and accepts an explicit backend for cross-compiled input.
-Native binaries omit `Requires: openssl-libs`; a local transitional
-OpenSSL-adapter binary retains it, and an unknown backend fails packaging.
+Like the DEB builder, the RPM builder always proves the packaged binary's
+native identity with `scripts/audit-release-binary.sh` instead of trusting a
+caller-supplied backend flag: self-audited when `--binary` is host-executable,
+or via a SHA-256-matched `--audit-inventory` file (see the DEB section above)
+for cross-architecture packaging. Every produced package omits
+`Requires: openssl-libs`; there is no other production backend to package.
 
 Like the DEB package, the RPM installs a starter
 `/etc/tardigrade/tardigrade.conf`, creates `/var/lib/tardigrade` (the
@@ -216,9 +235,11 @@ docker compose up -d
 
 The current image is a multi-stage build (Zig toolchain in the build stage,
 `tardi` plus its current runtime dependencies in the final stage) that runs as
-a non-root `tardigrade` user. Docker's native-only shipping cutover is tracked
-separately by #634; #476 does not claim that local image is already migrated.
-See [docs/DEPLOYMENT.md](../docs/DEPLOYMENT.md) for the complete Docker workflow
+a non-root `tardigrade` user. Neither stage installs OpenSSL/libcrypto for
+Tardigrade (#650); `scripts/test-docker-image.sh` extracts the exact runtime
+binary and audits it with `scripts/audit-release-binary.sh` rather than
+inferring composition from the Dockerfile text. See
+[docs/DEPLOYMENT.md](../docs/DEPLOYMENT.md) for the complete Docker workflow
 — build, config validation, start, reload, and graceful stop — alongside the
 equivalent systemd path.
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -106,10 +106,13 @@ for architectures the release workflow doesn't cover, or a custom build. Use
 the native profile for a shipping-equivalent package:
 
 ```bash
-# 1. Build the binary first (cross-compile for the target arch as needed)
+# 1. Install prerequisites
+apt install jq
+
+# 2. Build the binary first (cross-compile for the target arch as needed)
 zig build -Doptimize=ReleaseFast
 
-# 2. Build the DEB.
+# 3. Build the DEB.
 ./packaging/deb/build.sh \
   --version 0.50 \
   --arch amd64

--- a/packaging/deb/build.sh
+++ b/packaging/deb/build.sh
@@ -2,18 +2,34 @@
 # Build a Debian/Ubuntu .deb package for Tardigrade.
 #
 # Usage:
-#   ./packaging/deb/build.sh [--version VERSION] [--arch ARCH] [--binary PATH]
+#   ./packaging/deb/build.sh [--version VERSION] [--arch ARCH] [--binary PATH] \
+#       [--profile {general|appliance}] [--audit-inventory PATH] [--output DIR]
 #
 # Options:
-#   --version VERSION       Package version (default: inferred from `git describe`)
-#   --arch ARCH             Target architecture: amd64 or arm64 (default: host arch)
-#   --binary PATH           Path to pre-built tardi binary (default: zig-out/bin/tardi)
-#   --tls-backend BACKEND   native or openssl-adapter. When omitted, infer from
-#                           the executable binary's `tardi version` output.
-#   --output DIR            Output directory for .deb file (default: dist/)
+#   --version VERSION        Package version (default: inferred from `git describe`)
+#   --arch ARCH              Target architecture: amd64 or arm64 (default: host arch)
+#   --binary PATH            Path to pre-built tardi binary (default: zig-out/bin/tardi)
+#   --profile PROFILE        TLS/crypto product policy the binary was built with:
+#                             general or appliance (default: general, the
+#                             general-purpose native profile this builder ships)
+#   --audit-inventory PATH   A scripts/audit-release-binary.sh --output inventory
+#                             JSON already generated for this exact BINARY (matched
+#                             by SHA-256). Required when BINARY cannot execute on
+#                             this host (cross-architecture packaging); ignored
+#                             otherwise in favor of a fresh self-audit.
+#   --output DIR             Output directory for .deb file (default: dist/)
+#
+# Tardigrade ships exactly one production TLS/crypto implementation: the
+# native path, with no OpenSSL/libcrypto (or other foreign TLS/crypto/QUIC/H3)
+# linkage (#649). This builder proves that with scripts/audit-release-binary.sh
+# rather than trusting a caller-supplied backend flag, and the resulting
+# package declares no OpenSSL runtime dependency.
 #
 # Prerequisites:
 #   dpkg-deb (part of dpkg, available on Debian/Ubuntu)
+#   jq
+#   scripts/audit-release-binary.sh's own prerequisites (readelf/objdump on
+#   Linux, otool on macOS)
 #   A pre-built tardi binary for the target architecture
 
 set -euo pipefail
@@ -22,16 +38,18 @@ REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 VERSION=""
 ARCH=""
 BINARY="${REPO_ROOT}/zig-out/bin/tardi"
-TLS_BACKEND=""
+PROFILE="general"
+AUDIT_INVENTORY=""
 OUTPUT_DIR="${REPO_ROOT}/dist"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --version)     VERSION="$2"; shift 2 ;;
-        --arch)        ARCH="$2"; shift 2 ;;
-        --binary)      BINARY="$2"; shift 2 ;;
-        --tls-backend) TLS_BACKEND="$2"; shift 2 ;;
-        --output)      OUTPUT_DIR="$2"; shift 2 ;;
+        --version)         VERSION="$2"; shift 2 ;;
+        --arch)            ARCH="$2"; shift 2 ;;
+        --binary)          BINARY="$2"; shift 2 ;;
+        --profile)         PROFILE="$2"; shift 2 ;;
+        --audit-inventory) AUDIT_INVENTORY="$2"; shift 2 ;;
+        --output)          OUTPUT_DIR="$2"; shift 2 ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
 done
@@ -55,42 +73,63 @@ if [[ ! -f "$BINARY" ]]; then
     exit 1
 fi
 
-# Package dependency metadata follows the artifact actually being packaged.
-# Host-native binaries (including the official release binary after its native
-# linkage audit) are inferred from their self-report. Cross-compiled binaries
-# that cannot execute on the packaging host remain supported by passing
-# --tls-backend explicitly instead of guessing from the target filename.
-if [[ -z "$TLS_BACKEND" ]]; then
-    if [[ ! -x "$BINARY" ]]; then
-        echo "Binary is not executable on this host; pass --tls-backend native or --tls-backend openssl-adapter" >&2
+case "$PROFILE" in
+    general | appliance) ;;
+    *) echo "Invalid --profile '$PROFILE' (expected general or appliance)" >&2; exit 1 ;;
+esac
+
+# ── Prove the packaged artifact is the native production implementation ────
+# The only supported production Tardigrade implementation is the native
+# TLS/crypto path (#649). This must never be established by a caller-provided
+# boolean/backend flag or inferred from the binary's filename -- always by
+# running (or checking the result of) scripts/audit-release-binary.sh.
+AUDIT_DIR=$(mktemp -d)
+trap 'rm -rf "$AUDIT_DIR"' EXIT
+AUDIT_JSON="${AUDIT_DIR}/audit.json"
+
+if [[ -x "$BINARY" ]] && "$BINARY" version >/dev/null 2>&1; then
+    "${REPO_ROOT}/scripts/audit-release-binary.sh" \
+        --binary "$BINARY" \
+        --profile "$PROFILE" \
+        --output "$AUDIT_JSON"
+elif [[ -n "$AUDIT_INVENTORY" ]]; then
+    if [[ ! -f "$AUDIT_INVENTORY" ]]; then
+        echo "Audit inventory not found: $AUDIT_INVENTORY" >&2
         exit 1
     fi
-    BINARY_VERSION_OUTPUT="$("$BINARY" version 2>/dev/null || true)"
-    case "$BINARY_VERSION_OUTPUT" in
-        *"tls-backend=native"*) TLS_BACKEND="native" ;;
-        *"tls-backend=openssl-adapter"*) TLS_BACKEND="openssl-adapter" ;;
-        *)
-            echo "Unable to determine TLS backend from '$BINARY version'; pass --tls-backend explicitly" >&2
-            exit 1
-            ;;
-    esac
+    if command -v sha256sum >/dev/null 2>&1; then
+        binary_sha256="$(sha256sum "$BINARY" | awk '{print $1}')"
+    else
+        binary_sha256="$(shasum -a 256 "$BINARY" | awk '{print $1}')"
+    fi
+    inventory_sha256="$(jq -r '.binary_sha256 // empty' "$AUDIT_INVENTORY")"
+    if [[ -z "$inventory_sha256" || "$inventory_sha256" != "$binary_sha256" ]]; then
+        echo "Audit inventory SHA-256 does not match --binary '$BINARY'; it was not generated for this exact artifact" >&2
+        exit 1
+    fi
+    cp "$AUDIT_INVENTORY" "$AUDIT_JSON"
+else
+    echo "Binary is not executable on this host (cross-architecture packaging)." >&2
+    echo "Pass --audit-inventory pointing to a scripts/audit-release-binary.sh --output" >&2
+    echo "inventory JSON already generated for this exact binary (e.g. on the target" >&2
+    echo "architecture, or under emulation)." >&2
+    exit 1
 fi
 
-OPENSSL_DEPENDS=""
-case "$TLS_BACKEND" in
-    native) ;;
-    openssl-adapter) OPENSSL_DEPENDS="Depends: libssl3 | libssl1.1" ;;
-    *)
-        echo "Invalid --tls-backend '$TLS_BACKEND' (expected native or openssl-adapter)" >&2
-        exit 1
-        ;;
-esac
+if [[ "$(jq -r '.status' "$AUDIT_JSON")" != "pass" ]] ||
+   [[ "$(jq -r '.reported_backend' "$AUDIT_JSON")" != "native" ]] ||
+   [[ "$(jq -r '.links_openssl' "$AUDIT_JSON")" != "false" ]] ||
+   [[ "$(jq -r '.reported_profile' "$AUDIT_JSON")" != "$PROFILE" ]]; then
+    echo "Audit does not prove a native, OpenSSL-free '$PROFILE' production artifact:" >&2
+    jq -r '.violations[]? // empty' "$AUDIT_JSON" >&2 || true
+    exit 1
+fi
 
 echo "Building tardigrade_${VERSION}_${ARCH}.deb ..."
 
 # ── Package tree ─────────────────────────────────────────────────────────────
 WORK_DIR=$(mktemp -d)
-trap 'rm -rf "$WORK_DIR"' EXIT
+trap 'rm -rf "$WORK_DIR" "$AUDIT_DIR"' EXIT
 
 PKG_DIR="${WORK_DIR}/tardigrade_${VERSION}_${ARCH}"
 BIN_DIR="${PKG_DIR}/usr/bin"
@@ -150,19 +189,14 @@ cat > "${DEBIAN_DIR}/conffiles" <<'CONFEOF'
 /etc/tardigrade/tardigrade.env
 CONFEOF
 
-# DEBIAN/control. Do not emit a blank paragraph when the native package has no
-# OpenSSL dependency: Debian control-file paragraphs are separated by blanks.
+# DEBIAN/control. The native package declares no OpenSSL/libssl/libcrypto
+# runtime dependency for Tardigrade -- there is no other production backend.
 cat > "${DEBIAN_DIR}/control" <<CONTROL
 Package: tardigrade
 Version: ${VERSION}
 Architecture: ${ARCH}
 Maintainer: Bare Systems <security@baresystems.dev>
 Installed-Size: $(du -sk "$BIN_DIR" | awk '{print $1}')
-CONTROL
-if [[ -n "$OPENSSL_DEPENDS" ]]; then
-    printf '%s\n' "$OPENSSL_DEPENDS" >> "${DEBIAN_DIR}/control"
-fi
-cat >> "${DEBIAN_DIR}/control" <<CONTROL
 Section: net
 Priority: optional
 Homepage: https://github.com/Bare-Systems/Tardigrade

--- a/packaging/rpm/build.sh
+++ b/packaging/rpm/build.sh
@@ -2,13 +2,31 @@
 # Build an RPM package for Tardigrade.
 #
 # Usage:
-#   ./packaging/rpm/build.sh [--version VERSION] [--arch ARCH] [--binary PATH] [--tls-backend BACKEND] [--output DIR]
+#   ./packaging/rpm/build.sh [--version VERSION] [--arch ARCH] [--binary PATH] \
+#       [--profile {general|appliance}] [--audit-inventory PATH] [--output DIR]
 #
 # ARCH accepts Debian-style names (amd64, arm64) or RPM-style (x86_64, aarch64).
-# --tls-backend accepts native or openssl-adapter. When omitted, it is inferred
-# from an executable host-native binary's `tardi version` output.
+#
+# --profile is the TLS/crypto product policy the binary was built with:
+# general or appliance (default: general, the general-purpose native profile
+# this builder ships).
+#
+# --audit-inventory is a scripts/audit-release-binary.sh --output inventory
+# JSON already generated for this exact BINARY (matched by SHA-256). Required
+# when BINARY cannot execute on this host (cross-architecture packaging);
+# ignored otherwise in favor of a fresh self-audit.
+#
+# Tardigrade ships exactly one production TLS/crypto implementation: the
+# native path, with no OpenSSL/libcrypto (or other foreign TLS/crypto/QUIC/H3)
+# linkage (#649). This builder proves that with scripts/audit-release-binary.sh
+# rather than trusting a caller-supplied backend flag, and the resulting
+# package declares no OpenSSL runtime dependency.
+#
 # Prerequisites:
 #   rpm-build (dnf install rpm-build / apt-get install rpm-build)
+#   jq
+#   scripts/audit-release-binary.sh's own prerequisites (readelf/objdump on
+#   Linux, otool on macOS)
 #   A pre-built tardi binary
 
 set -euo pipefail
@@ -17,16 +35,18 @@ REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 VERSION=""
 ARCH=""
 BINARY="${REPO_ROOT}/zig-out/bin/tardi"
-TLS_BACKEND=""
+PROFILE="general"
+AUDIT_INVENTORY=""
 OUTPUT_DIR="${REPO_ROOT}/dist"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --version)     VERSION="$2"; shift 2 ;;
-        --arch)        ARCH="$2"; shift 2 ;;
-        --binary)      BINARY="$2"; shift 2 ;;
-        --tls-backend) TLS_BACKEND="$2"; shift 2 ;;
-        --output)      OUTPUT_DIR="$2"; shift 2 ;;
+        --version)         VERSION="$2"; shift 2 ;;
+        --arch)            ARCH="$2"; shift 2 ;;
+        --binary)          BINARY="$2"; shift 2 ;;
+        --profile)         PROFILE="$2"; shift 2 ;;
+        --audit-inventory) AUDIT_INVENTORY="$2"; shift 2 ;;
+        --output)          OUTPUT_DIR="$2"; shift 2 ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
 done
@@ -48,40 +68,62 @@ if [[ ! -f "$BINARY" ]]; then
     exit 1
 fi
 
-# Keep package metadata aligned with the exact artifact being packaged.
-# Host-native binaries (including the official release binary after its native
-# linkage audit) are inferred from their self-report. Cross-compiled binaries
-# remain packageable by passing the backend explicitly rather than attempting
-# to infer it by executing a foreign-architecture file.
-if [[ -z "$TLS_BACKEND" ]]; then
-    if [[ ! -x "$BINARY" ]]; then
-        echo "Binary is not executable on this host; pass --tls-backend native or --tls-backend openssl-adapter" >&2
+case "$PROFILE" in
+    general | appliance) ;;
+    *) echo "Invalid --profile '$PROFILE' (expected general or appliance)" >&2; exit 1 ;;
+esac
+
+# ── Prove the packaged artifact is the native production implementation ────
+# The only supported production Tardigrade implementation is the native
+# TLS/crypto path (#649). This must never be established by a caller-provided
+# boolean/backend flag or inferred from the binary's filename -- always by
+# running (or checking the result of) scripts/audit-release-binary.sh.
+AUDIT_DIR=$(mktemp -d)
+trap 'rm -rf "$AUDIT_DIR"' EXIT
+AUDIT_JSON="${AUDIT_DIR}/audit.json"
+
+if [[ -x "$BINARY" ]] && "$BINARY" version >/dev/null 2>&1; then
+    "${REPO_ROOT}/scripts/audit-release-binary.sh" \
+        --binary "$BINARY" \
+        --profile "$PROFILE" \
+        --output "$AUDIT_JSON"
+elif [[ -n "$AUDIT_INVENTORY" ]]; then
+    if [[ ! -f "$AUDIT_INVENTORY" ]]; then
+        echo "Audit inventory not found: $AUDIT_INVENTORY" >&2
         exit 1
     fi
-    BINARY_VERSION_OUTPUT="$("$BINARY" version 2>/dev/null || true)"
-    case "$BINARY_VERSION_OUTPUT" in
-        *"tls-backend=native"*) TLS_BACKEND="native" ;;
-        *"tls-backend=openssl-adapter"*) TLS_BACKEND="openssl-adapter" ;;
-        *)
-            echo "Unable to determine TLS backend from '$BINARY version'; pass --tls-backend explicitly" >&2
-            exit 1
-            ;;
-    esac
+    if command -v sha256sum >/dev/null 2>&1; then
+        binary_sha256="$(sha256sum "$BINARY" | awk '{print $1}')"
+    else
+        binary_sha256="$(shasum -a 256 "$BINARY" | awk '{print $1}')"
+    fi
+    inventory_sha256="$(jq -r '.binary_sha256 // empty' "$AUDIT_INVENTORY")"
+    if [[ -z "$inventory_sha256" || "$inventory_sha256" != "$binary_sha256" ]]; then
+        echo "Audit inventory SHA-256 does not match --binary '$BINARY'; it was not generated for this exact artifact" >&2
+        exit 1
+    fi
+    cp "$AUDIT_INVENTORY" "$AUDIT_JSON"
+else
+    echo "Binary is not executable on this host (cross-architecture packaging)." >&2
+    echo "Pass --audit-inventory pointing to a scripts/audit-release-binary.sh --output" >&2
+    echo "inventory JSON already generated for this exact binary (e.g. on the target" >&2
+    echo "architecture, or under emulation)." >&2
+    exit 1
 fi
 
-case "$TLS_BACKEND" in
-    native) RPM_REQUIRES_OPENSSL=0 ;;
-    openssl-adapter) RPM_REQUIRES_OPENSSL=1 ;;
-    *)
-        echo "Invalid --tls-backend '$TLS_BACKEND' (expected native or openssl-adapter)" >&2
-        exit 1
-        ;;
-esac
+if [[ "$(jq -r '.status' "$AUDIT_JSON")" != "pass" ]] ||
+   [[ "$(jq -r '.reported_backend' "$AUDIT_JSON")" != "native" ]] ||
+   [[ "$(jq -r '.links_openssl' "$AUDIT_JSON")" != "false" ]] ||
+   [[ "$(jq -r '.reported_profile' "$AUDIT_JSON")" != "$PROFILE" ]]; then
+    echo "Audit does not prove a native, OpenSSL-free '$PROFILE' production artifact:" >&2
+    jq -r '.violations[]? // empty' "$AUDIT_JSON" >&2 || true
+    exit 1
+fi
 
 echo "Building tardigrade-${VERSION}-1.${RPM_ARCH}.rpm ..."
 
 WORK_DIR=$(mktemp -d)
-trap 'rm -rf "$WORK_DIR"' EXIT
+trap 'rm -rf "$WORK_DIR" "$AUDIT_DIR"' EXIT
 
 mkdir -p "${WORK_DIR}"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
@@ -118,7 +160,6 @@ LREOF
 rpmbuild --define "_topdir ${WORK_DIR}" \
          --define "version ${VERSION}" \
          --define "build_arch ${RPM_ARCH}" \
-         --define "tardigrade_requires_openssl ${RPM_REQUIRES_OPENSSL}" \
          --define "_unitdir /usr/lib/systemd/system" \
          --target "${RPM_ARCH}-linux" \
          -bb "${WORK_DIR}/SPECS/tardigrade.spec"

--- a/packaging/rpm/tardigrade.spec
+++ b/packaging/rpm/tardigrade.spec
@@ -12,9 +12,6 @@ Source4:        tardigrade.conf
 Source5:        tardigrade.logrotate
 
 BuildArch:      %{build_arch}
-%if 0%{?tardigrade_requires_openssl}
-Requires:       openssl-libs
-%endif
 
 %description
 High-performance Zig edge gateway and HTTP server for TLS termination,

--- a/scripts/audit-release-binary.sh
+++ b/scripts/audit-release-binary.sh
@@ -3,10 +3,14 @@
 # cutover #634, retirement #649).
 #
 # Inspects a produced tardi binary's dynamic dependencies and emits a
-# machine-readable inventory. Every supported profile (`general` and
-# `appliance`) is native-only: this fails if the binary links OpenSSL,
-# libcrypto, or any other foreign TLS/crypto/QUIC/H3/certificate library, and
-# confirms the binary self-reports the native TLS path.
+# machine-readable inventory (including a SHA-256 checksum of the audited
+# binary, so a consumer that cannot execute it directly -- e.g. a
+# cross-architecture package builder -- can still bind the audit result to the
+# exact artifact bytes instead of trusting an unverified file). Every
+# supported profile (`general` and `appliance`) is native-only: this fails if
+# the binary links OpenSSL, libcrypto, or any other foreign
+# TLS/crypto/QUIC/H3/certificate library, and confirms the binary self-reports
+# the native TLS path.
 #
 # Usage:
 #   audit-release-binary.sh --binary PATH --profile {general|appliance} \
@@ -131,6 +135,19 @@ Darwin)
     ;;
 esac
 
+# ── Binary checksum ───────────────────────────────────────────────────────────
+# Lets a consumer of the emitted inventory (e.g. a cross-architecture package
+# builder that cannot execute this binary itself) bind the audit result to the
+# exact artifact bytes instead of trusting an unverified caller-supplied file.
+if command -v sha256sum >/dev/null 2>&1; then
+    binary_sha256="$(sha256sum "$BINARY" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+    binary_sha256="$(shasum -a 256 "$BINARY" | awk '{print $1}')"
+else
+    echo "inspection failed: neither sha256sum nor shasum is available" >&2
+    exit 2
+fi
+
 links_openssl=false
 if printf '%s\n' "$dep_names" | grep -qiE 'libssl|libcrypto'; then
     links_openssl=true
@@ -186,6 +203,7 @@ fi
 emit_inventory() {
     printf '{\n'
     printf '  "binary": %s,\n' "$(json_string "$BINARY")"
+    printf '  "binary_sha256": %s,\n' "$(json_string "$binary_sha256")"
     printf '  "profile": %s,\n' "$(json_string "$PROFILE")"
     printf '  "host_os": %s,\n' "$(json_string "$os")"
     printf '  "inspection_tool": %s,\n' "$(json_string "$inspection_tool")"

--- a/scripts/test-deb-package.sh
+++ b/scripts/test-deb-package.sh
@@ -45,6 +45,27 @@ fi
 DEB_PATH="${OUTPUT_DIR}/tardigrade_${VERSION}_amd64.deb"
 test -f "$DEB_PATH"
 
+# ── Regression: the standalone builder must not accept a caller-asserted
+# OpenSSL backend as a valid production mode (#650) ─────────────────────────
+if "${REPO_ROOT}/packaging/deb/build.sh" \
+    --version "$VERSION" \
+    --arch amd64 \
+    --binary "$BINARY" \
+    --tls-backend openssl-adapter \
+    --output "${OUTPUT_DIR}/rejected" 2>/dev/null; then
+    echo "FAIL: deb builder accepted --tls-backend openssl-adapter" >&2
+    exit 1
+fi
+echo "deb builder: --tls-backend openssl-adapter correctly rejected"
+
+# ── Regression: package metadata must declare no OpenSSL runtime dependency ──
+DEB_DEPENDS="$(dpkg-deb -f "$DEB_PATH" Depends 2>/dev/null || true)"
+if printf '%s\n' "$DEB_DEPENDS" | grep -qiE 'libssl|libcrypto|openssl'; then
+    echo "FAIL: native DEB unexpectedly declares an OpenSSL dependency: $DEB_DEPENDS" >&2
+    exit 1
+fi
+echo "deb metadata: no OpenSSL dependency"
+
 if ! retry 3 docker pull "$DEB_TEST_IMAGE"; then
     echo "CI infrastructure failure: unable to pull DEB smoke test image ($DEB_TEST_IMAGE)" >&2
     exit 75
@@ -56,7 +77,7 @@ docker run --pull=never --rm -v "${OUTPUT_DIR}:/artifacts:ro" "$DEB_TEST_IMAGE" 
         echo "CI infrastructure failure: apt index refresh failed in DEB smoke setup" >&2
         exit 75
     fi
-    if ! apt-get -o Acquire::Retries=3 install -y ca-certificates libssl3; then
+    if ! apt-get -o Acquire::Retries=3 install -y ca-certificates; then
         echo "CI infrastructure failure: apt dependency bootstrap failed in DEB smoke setup" >&2
         exit 75
     fi

--- a/scripts/test-deb-package.sh
+++ b/scripts/test-deb-package.sh
@@ -58,6 +58,43 @@ if "${REPO_ROOT}/packaging/deb/build.sh" \
 fi
 echo "deb builder: --tls-backend openssl-adapter correctly rejected"
 
+# ── Regression: cross-architecture packaging via --audit-inventory (#650) ───
+# The audit-inventory path is what preserves cross-architecture packaging
+# without a caller-asserted backend flag; exercise it here (a non-executable
+# copy of the host binary stands in for a foreign-architecture artifact)
+# rather than leaving it validated only by hand.
+NONEXEC_BINARY="${TMPDIR}/tardi-nonexec"
+cp "$BINARY" "$NONEXEC_BINARY"
+chmod -x "$NONEXEC_BINARY"
+INVENTORY_PATH="${TMPDIR}/audit-inventory.json"
+"${REPO_ROOT}/scripts/audit-release-binary.sh" \
+    --binary "$BINARY" \
+    --profile general \
+    --output "$INVENTORY_PATH"
+"${REPO_ROOT}/packaging/deb/build.sh" \
+    --version "$VERSION" \
+    --arch amd64 \
+    --binary "$NONEXEC_BINARY" \
+    --audit-inventory "$INVENTORY_PATH" \
+    --output "${OUTPUT_DIR}/cross-arch"
+test -f "${OUTPUT_DIR}/cross-arch/tardigrade_${VERSION}_amd64.deb"
+echo "deb builder: --audit-inventory cross-architecture path succeeded"
+
+# A mismatched inventory (not generated for this exact binary) must be rejected.
+OTHER_INVENTORY="${TMPDIR}/audit-inventory-mismatched.json"
+jq '.binary_sha256 = "0000000000000000000000000000000000000000000000000000000000000"' \
+    "$INVENTORY_PATH" > "$OTHER_INVENTORY"
+if "${REPO_ROOT}/packaging/deb/build.sh" \
+    --version "$VERSION" \
+    --arch amd64 \
+    --binary "$NONEXEC_BINARY" \
+    --audit-inventory "$OTHER_INVENTORY" \
+    --output "${OUTPUT_DIR}/rejected-mismatch" 2>/dev/null; then
+    echo "FAIL: deb builder accepted an --audit-inventory with a mismatched SHA-256" >&2
+    exit 1
+fi
+echo "deb builder: mismatched --audit-inventory correctly rejected"
+
 # ── Regression: package metadata must declare no OpenSSL runtime dependency ──
 DEB_DEPENDS="$(dpkg-deb -f "$DEB_PATH" Depends 2>/dev/null || true)"
 if printf '%s\n' "$DEB_DEPENDS" | grep -qiE 'libssl|libcrypto|openssl'; then
@@ -71,19 +108,53 @@ if ! retry 3 docker pull "$DEB_TEST_IMAGE"; then
     exit 75
 fi
 
-docker run --pull=never --rm -v "${OUTPUT_DIR}:/artifacts:ro" "$DEB_TEST_IMAGE" bash -euxc '
+docker run --pull=never --rm \
+    -v "${OUTPUT_DIR}:/artifacts:ro" \
+    -v "${REPO_ROOT}/scripts/audit-release-binary.sh:/opt/audit-release-binary.sh:ro" \
+    "$DEB_TEST_IMAGE" bash -euxc '
     export DEBIAN_FRONTEND=noninteractive
     if ! apt-get -o Acquire::Retries=3 update; then
         echo "CI infrastructure failure: apt index refresh failed in DEB smoke setup" >&2
         exit 75
     fi
-    if ! apt-get -o Acquire::Retries=3 install -y ca-certificates; then
+    if ! apt-get -o Acquire::Retries=3 install -y ca-certificates curl binutils; then
         echo "CI infrastructure failure: apt dependency bootstrap failed in DEB smoke setup" >&2
         exit 75
     fi
     apt-get -o Acquire::Retries=3 install -y /artifacts/tardigrade_0.0.0-smoke_amd64.deb
     test -x /usr/bin/tardi
     /usr/bin/tardi version >/dev/null
+
+    # Audit the exact binary actually installed by the package (#650) --
+    # metadata/layout checks alone would not catch a package that installs
+    # a binary linking OpenSSL, or one that mismatches its own reported
+    # identity.
+    bash /opt/audit-release-binary.sh \
+        --binary /usr/bin/tardi \
+        --profile general \
+        --output /tmp/deb-inventory.json
+
+    # A real request against the installed binary/config, not just `tardi
+    # version` (#650): start it with the same starter config the package
+    # ships, wait for a live response, then stop it.
+    tardi run -c /etc/tardigrade/tardigrade.conf &
+    tardi_pid=$!
+    ready=false
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if curl -fsS -H "Host: localhost" http://127.0.0.1:8069/health >/dev/null 2>&1; then
+            ready=true
+            break
+        fi
+        sleep 1
+    done
+    if [ "$ready" != true ]; then
+        echo "FAIL: installed tardi never became ready to serve /health" >&2
+        exit 1
+    fi
+    curl -fsS -H "Host: localhost" http://127.0.0.1:8069/health
+    kill "$tardi_pid"
+    wait "$tardi_pid" 2>/dev/null || true
+
     test -f /etc/tardigrade/tardigrade.conf
     test -f /etc/tardigrade/tardigrade.env
     test -f /lib/systemd/system/tardigrade.service

--- a/scripts/test-docker-image.sh
+++ b/scripts/test-docker-image.sh
@@ -13,9 +13,10 @@ CONTAINER_NAME="tardigrade-smoke-test"
 TMPDIR="$(mktemp -d)"
 
 PIDCHECK_CONTAINER_NAME="${CONTAINER_NAME}-pidcheck"
+AUDIT_CONTAINER_NAME="${CONTAINER_NAME}-audit"
 
 cleanup() {
-    docker rm -f "$CONTAINER_NAME" "$PIDCHECK_CONTAINER_NAME" >/dev/null 2>&1 || true
+    docker rm -f "$CONTAINER_NAME" "$PIDCHECK_CONTAINER_NAME" "$AUDIT_CONTAINER_NAME" >/dev/null 2>&1 || true
     docker rmi "$IMAGE_TAG" >/dev/null 2>&1 || true
     rm -rf "$TMPDIR"
 }
@@ -54,6 +55,22 @@ fi
 
 # ── Build ─────────────────────────────────────────────────────────────────────
 docker build -t "$IMAGE_TAG" "$REPO_ROOT"
+
+# ── Audit the exact runtime binary for native-only linkage/identity ─────────
+# Composition must never be inferred from Dockerfile text alone: extract the
+# precise binary copied into the runtime stage and run the same linkage/
+# self-report audit the release pipeline runs, proving it links no
+# OpenSSL/libcrypto (or other foreign TLS/crypto/QUIC/H3) library and
+# self-reports the native production identity.
+docker create --name "$AUDIT_CONTAINER_NAME" "$IMAGE_TAG" >/dev/null
+docker cp "${AUDIT_CONTAINER_NAME}:/usr/local/bin/tardi" "$TMPDIR/tardi"
+docker rm -f "$AUDIT_CONTAINER_NAME" >/dev/null 2>&1
+chmod +x "$TMPDIR/tardi"
+"${REPO_ROOT}/scripts/audit-release-binary.sh" \
+    --binary "$TMPDIR/tardi" \
+    --profile general \
+    --output "$TMPDIR/dependency-inventory.json"
+echo "docker runtime binary: native-only linkage audit passed"
 
 # ── Runtime image must not contain Zig/compiler build tooling ───────────────
 if docker run --rm --entrypoint sh "$IMAGE_TAG" -c 'command -v zig' >/dev/null 2>&1; then

--- a/scripts/test-docker-image.sh
+++ b/scripts/test-docker-image.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 IMAGE_TAG="tardigrade-smoke-test:local"
+BUILD_IMAGE_TAG="tardigrade-smoke-test-build:local"
 CONTAINER_NAME="tardigrade-smoke-test"
 TMPDIR="$(mktemp -d)"
 
@@ -17,7 +18,7 @@ AUDIT_CONTAINER_NAME="${CONTAINER_NAME}-audit"
 
 cleanup() {
     docker rm -f "$CONTAINER_NAME" "$PIDCHECK_CONTAINER_NAME" "$AUDIT_CONTAINER_NAME" >/dev/null 2>&1 || true
-    docker rmi "$IMAGE_TAG" >/dev/null 2>&1 || true
+    docker rmi "$IMAGE_TAG" "$BUILD_IMAGE_TAG" >/dev/null 2>&1 || true
     rm -rf "$TMPDIR"
 }
 trap cleanup EXIT
@@ -55,6 +56,37 @@ fi
 
 # ── Build ─────────────────────────────────────────────────────────────────────
 docker build -t "$IMAGE_TAG" "$REPO_ROOT"
+docker build --target build -t "$BUILD_IMAGE_TAG" "$REPO_ROOT"
+
+# ── Neither stage explicitly installs an OpenSSL/libcrypto package ─────────
+# The binary linkage audit below proves the shipped artifact doesn't *link*
+# OpenSSL, but that alone would not catch a Dockerfile regression that
+# re-installs libssl-dev/libssl3 without anything ending up linked against
+# them (#650's close rule requires catching Docker re-installing OpenSSL, not
+# just re-linking it).
+#
+# A raw dpkg presence check is not the right test here: on this base image,
+# ca-certificates has a genuine transitive `Depends: openssl` (which in turn
+# depends on libssl3) for its own certificate-bundle tooling, so libssl3 is
+# unavoidably present regardless of anything Tardigrade does -- that is
+# exactly the "ordinary OS/package substrate" the issue says must not be
+# confused with a foreign product implementation. `apt-mark showmanual`
+# distinguishes packages the Dockerfile explicitly named on an `apt-get
+# install` line from ones pulled in only as someone else's dependency, so it
+# catches a real Dockerfile regression without false-failing on
+# ca-certificates' own dependency chain.
+FORBIDDEN_PACKAGES_PATTERN='^(libssl-dev|libssl3|libssl1\.1|openssl)$'
+if docker run --rm --entrypoint sh "$BUILD_IMAGE_TAG" -c "apt-mark showmanual | grep -qE '$FORBIDDEN_PACKAGES_PATTERN'"; then
+    echo "FAIL: build stage explicitly installs an OpenSSL package; Tardigrade's native build needs no OpenSSL headers" >&2
+    exit 1
+fi
+echo "build stage: no OpenSSL package explicitly installed"
+
+if docker run --rm --entrypoint sh "$IMAGE_TAG" -c "apt-mark showmanual | grep -qE '$FORBIDDEN_PACKAGES_PATTERN'"; then
+    echo "FAIL: runtime image explicitly installs an OpenSSL package; Tardigrade's native binary needs no OpenSSL runtime library" >&2
+    exit 1
+fi
+echo "runtime stage: no OpenSSL package explicitly installed"
 
 # ── Audit the exact runtime binary for native-only linkage/identity ─────────
 # Composition must never be inferred from Dockerfile text alone: extract the

--- a/scripts/test-homebrew-tap-sync.sh
+++ b/scripts/test-homebrew-tap-sync.sh
@@ -56,8 +56,8 @@ JSON
             dependency-inventory-tardigrade-linux-x86_64.json)
                 cat > "$dir/dependency-inventory-tardigrade-linux-x86_64.json" <<'JSON'
 {
-  "profile": "native",
-  "reported_profile": "native",
+  "profile": "general",
+  "reported_profile": "general",
   "reported_backend": "native",
   "links_openssl": false,
   "status": "pass"

--- a/scripts/test-rpm-package.sh
+++ b/scripts/test-rpm-package.sh
@@ -124,13 +124,18 @@ docker run --pull=never --rm \
         test -f "$rpm_path"
 
         # Regression: the standalone builder must not accept a caller-asserted
-        # OpenSSL backend as a valid production mode (#650).
+        # OpenSSL backend as a valid production mode (#650). --output targets
+        # a container-local /tmp path, not the host-bind-mounted /output: this
+        # call is expected to fail before ever writing anything, but even the
+        # happy-path calls below must never write into /output as root, since
+        # the host-side cleanup afterward runs as the unprivileged CI user and
+        # cannot remove root-owned files/directories it creates there.
         if /repo/packaging/rpm/build.sh \
             --version 0.0.0 \
             --arch "$zig_arch" \
             --binary /tmp/tardigrade/zig-out/bin/tardi \
             --tls-backend openssl-adapter \
-            --output /output/rejected 2>/dev/null; then
+            --output /tmp/rejected 2>/dev/null; then
             echo "FAIL: rpm builder accepted --tls-backend openssl-adapter" >&2
             exit 1
         fi
@@ -153,8 +158,8 @@ docker run --pull=never --rm \
             --arch "$zig_arch" \
             --binary /tmp/tardi-nonexec \
             --audit-inventory /tmp/audit-inventory.json \
-            --output /output/cross-arch
-        test -n "$(find /output/cross-arch -name "tardigrade-*.rpm" -print -quit)"
+            --output /tmp/output-cross-arch
+        test -n "$(find /tmp/output-cross-arch -name "tardigrade-*.rpm" -print -quit)"
         echo "rpm builder: --audit-inventory cross-architecture path succeeded"
 
         # A mismatched inventory (not generated for this exact binary) must be
@@ -166,7 +171,7 @@ docker run --pull=never --rm \
             --arch "$zig_arch" \
             --binary /tmp/tardi-nonexec \
             --audit-inventory /tmp/audit-inventory-mismatched.json \
-            --output /output/rejected-mismatch 2>/dev/null; then
+            --output /tmp/output-rejected-mismatch 2>/dev/null; then
             echo "FAIL: rpm builder accepted an --audit-inventory with a mismatched SHA-256" >&2
             exit 1
         fi

--- a/scripts/test-rpm-package.sh
+++ b/scripts/test-rpm-package.sh
@@ -72,9 +72,9 @@ docker run --pull=never --rm \
     --volume "${ZIG_DIR}:/opt/zig:ro" \
     "$RPM_TEST_IMAGE" bash -euxc '
         # Rocky minor repos can briefly offer a newer best candidate before all
-        # matching dependency packages are mirrored. The smoke test only needs a
-        # coherent distro-provided OpenSSL development stack.
-        if ! dnf --setopt=retries=3 --nobest install -y rpm-build openssl-devel openssl-libs systemd-rpm-macros; then
+        # matching dependency packages are mirrored. jq is required by
+        # packaging/rpm/build.sh to validate the native-linkage audit result.
+        if ! dnf --setopt=retries=3 --nobest install -y rpm-build systemd-rpm-macros jq; then
             echo "CI infrastructure failure: dnf dependency bootstrap failed in RPM smoke setup" >&2
             exit 75
         fi
@@ -114,6 +114,28 @@ docker run --pull=never --rm \
         rpm_path=$(find /output -name "tardigrade-*.rpm" | head -1)
         test -n "$rpm_path"
         test -f "$rpm_path"
+
+        # Regression: the standalone builder must not accept a caller-asserted
+        # OpenSSL backend as a valid production mode (#650).
+        if /repo/packaging/rpm/build.sh \
+            --version 0.0.0 \
+            --arch "$zig_arch" \
+            --binary /tmp/tardigrade/zig-out/bin/tardi \
+            --tls-backend openssl-adapter \
+            --output /output/rejected 2>/dev/null; then
+            echo "FAIL: rpm builder accepted --tls-backend openssl-adapter" >&2
+            exit 1
+        fi
+        echo "rpm builder: --tls-backend openssl-adapter correctly rejected"
+
+        # Regression: package metadata must declare no OpenSSL runtime dependency.
+        rpm_requires="$(rpm -qp --requires "$rpm_path")"
+        if printf "%s\n" "$rpm_requires" | grep -qiE "libssl|libcrypto|openssl"; then
+            echo "FAIL: native RPM unexpectedly declares an OpenSSL dependency:" >&2
+            printf "%s\n" "$rpm_requires" >&2
+            exit 1
+        fi
+        echo "rpm metadata: no OpenSSL dependency"
 
         dnf --setopt=retries=3 install -y "$rpm_path"
 

--- a/scripts/test-rpm-package.sh
+++ b/scripts/test-rpm-package.sh
@@ -73,8 +73,12 @@ docker run --pull=never --rm \
     "$RPM_TEST_IMAGE" bash -euxc '
         # Rocky minor repos can briefly offer a newer best candidate before all
         # matching dependency packages are mirrored. jq is required by
-        # packaging/rpm/build.sh to validate the native-linkage audit result.
-        if ! dnf --setopt=retries=3 --nobest install -y rpm-build systemd-rpm-macros jq; then
+        # packaging/rpm/build.sh to validate the native-linkage audit result;
+        # binutils (readelf) is required by scripts/audit-release-binary.sh.
+        # curl is not listed here: the base image already ships curl-minimal,
+        # which provides a fully working `curl` binary for the plain HTTP
+        # request below, and the full curl package conflicts with it.
+        if ! dnf --setopt=retries=3 --nobest install -y rpm-build systemd-rpm-macros jq binutils; then
             echo "CI infrastructure failure: dnf dependency bootstrap failed in RPM smoke setup" >&2
             exit 75
         fi
@@ -92,17 +96,21 @@ docker run --pull=never --rm \
         cd /tmp/tardigrade
         rm -rf zig-out .zig-cache
 
-        # glibc 2.34 (Rocky/RHEL 9'"'"'s version) merged libpthread into libc and
-        # re-versioned pthread_create/pthread_join/etc. under a new GLIBC_2.34
-        # symbol version. Zig'"'"'s default native-target glibc floor predates that,
-        # so it doesn'"'"'t know those symbol versions exist and dynamic linking
-        # against the real /usr/lib64/libssl.so fails with "undefined reference"
-        # even though the symbols are genuinely present at runtime. Passing an
-        # explicit glibc-version floor (not a ceiling -- linking is still against
-        # the real system libc.so.6 dynamically) fixes it; bare "native"/"native-native-gnu"
-        # does not, and was confirmed to reproduce the same failure.
+        # Before #649/#650, this needed an explicit glibc-version floor
+        # (`-Dtarget=$arch-linux-gnu.2.34`): glibc 2.34 (Rocky/RHEL 9'"'"'s
+        # version) merged libpthread into libc and re-versioned
+        # pthread_create/pthread_join/etc. under a new GLIBC_2.34 symbol
+        # version, and dynamically linking the OpenSSL adapter'"'"'s libssl.so
+        # pulled in those reversioned symbols before Zig'"'"'s default
+        # native-target glibc floor knew they existed, failing with
+        # "undefined reference" even though the symbols were genuinely
+        # present at runtime. Tardigrade'"'"'s native build links no OpenSSL (or
+        # any other foreign library) at all, so that failure no longer
+        # reproduces here -- confirmed by building this exact target with
+        # the bare native target and no explicit floor -- and the floor is
+        # not re-added.
         zig_arch="$(uname -m)"
-        zig build -Doptimize=ReleaseFast -Dtarget="${zig_arch}-linux-gnu.2.34"
+        zig build -Doptimize=ReleaseFast
         test -x zig-out/bin/tardi
 
         /repo/packaging/rpm/build.sh \
@@ -128,6 +136,42 @@ docker run --pull=never --rm \
         fi
         echo "rpm builder: --tls-backend openssl-adapter correctly rejected"
 
+        # Regression: cross-architecture packaging via --audit-inventory (#650).
+        # The audit-inventory path is what preserves cross-architecture
+        # packaging without a caller-asserted backend flag; exercise it here
+        # (a non-executable copy of the host binary stands in for a
+        # foreign-architecture artifact) rather than leaving it validated only
+        # by hand.
+        cp /tmp/tardigrade/zig-out/bin/tardi /tmp/tardi-nonexec
+        chmod -x /tmp/tardi-nonexec
+        /repo/scripts/audit-release-binary.sh \
+            --binary /tmp/tardigrade/zig-out/bin/tardi \
+            --profile general \
+            --output /tmp/audit-inventory.json
+        /repo/packaging/rpm/build.sh \
+            --version 0.0.0 \
+            --arch "$zig_arch" \
+            --binary /tmp/tardi-nonexec \
+            --audit-inventory /tmp/audit-inventory.json \
+            --output /output/cross-arch
+        test -n "$(find /output/cross-arch -name "tardigrade-*.rpm" -print -quit)"
+        echo "rpm builder: --audit-inventory cross-architecture path succeeded"
+
+        # A mismatched inventory (not generated for this exact binary) must be
+        # rejected.
+        jq ".binary_sha256 = \"0000000000000000000000000000000000000000000000000000000000000\"" \
+            /tmp/audit-inventory.json > /tmp/audit-inventory-mismatched.json
+        if /repo/packaging/rpm/build.sh \
+            --version 0.0.0 \
+            --arch "$zig_arch" \
+            --binary /tmp/tardi-nonexec \
+            --audit-inventory /tmp/audit-inventory-mismatched.json \
+            --output /output/rejected-mismatch 2>/dev/null; then
+            echo "FAIL: rpm builder accepted an --audit-inventory with a mismatched SHA-256" >&2
+            exit 1
+        fi
+        echo "rpm builder: mismatched --audit-inventory correctly rejected"
+
         # Regression: package metadata must declare no OpenSSL runtime dependency.
         rpm_requires="$(rpm -qp --requires "$rpm_path")"
         if printf "%s\n" "$rpm_requires" | grep -qiE "libssl|libcrypto|openssl"; then
@@ -141,6 +185,37 @@ docker run --pull=never --rm \
 
         test -x /usr/bin/tardi
         /usr/bin/tardi version >/dev/null
+
+        # Audit the exact binary actually installed by the package (#650) --
+        # metadata/layout checks alone would not catch a package that installs
+        # a binary linking OpenSSL, or one that mismatches its own reported
+        # identity.
+        /repo/scripts/audit-release-binary.sh \
+            --binary /usr/bin/tardi \
+            --profile general \
+            --output /tmp/rpm-installed-inventory.json
+
+        # A real request against the installed binary/config, not just `tardi
+        # version` (#650): start it with the same starter config the package
+        # ships, wait for a live response, then stop it.
+        tardi run -c /etc/tardigrade/tardigrade.conf &
+        tardi_pid=$!
+        ready=false
+        for _ in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -fsS -H "Host: localhost" http://127.0.0.1:8069/health >/dev/null 2>&1; then
+                ready=true
+                break
+            fi
+            sleep 1
+        done
+        if [ "$ready" != true ]; then
+            echo "FAIL: installed tardi never became ready to serve /health" >&2
+            exit 1
+        fi
+        curl -fsS -H "Host: localhost" http://127.0.0.1:8069/health
+        kill "$tardi_pid"
+        wait "$tardi_pid" 2>/dev/null || true
+
         test -f /etc/tardigrade/tardigrade.env
         test -f /etc/tardigrade/tardigrade.conf
         test -f /usr/lib/systemd/system/tardigrade.service

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -155,8 +155,8 @@ validate_native_inventory() {
 
     gh release download "$TAG" --repo "$REPO" --pattern "$inventory_asset" --dir "$tmpdir" --clobber
     inventory_path="$tmpdir/$inventory_asset"
-    if [ "$(jq -r '.profile' "$inventory_path")" != "native" ] ||
-        [ "$(jq -r '.reported_profile' "$inventory_path")" != "native" ] ||
+    if [ "$(jq -r '.profile' "$inventory_path")" != "general" ] ||
+        [ "$(jq -r '.reported_profile' "$inventory_path")" != "general" ] ||
         [ "$(jq -r '.reported_backend' "$inventory_path")" != "native" ] ||
         [ "$(jq -r '.links_openssl' "$inventory_path")" != "false" ] ||
         [ "$(jq -r '.status' "$inventory_path")" != "pass" ]; then


### PR DESCRIPTION
## Summary
- Root `Dockerfile`: removed `libssl-dev` from the build stage and `libssl3` from the runtime stage. The default `general` TLS profile has been pure-Zig native since #649, so neither is needed to build or run `tardi`.
- `scripts/test-docker-image.sh`: extracts the exact binary copied into the runtime stage and audits it with `scripts/audit-release-binary.sh` (linkage + self-report); also builds the `build` target and asserts neither stage *explicitly* installs an OpenSSL package (`apt-mark showmanual`, not a raw `dpkg -l` presence check — `ca-certificates` has a genuine transitive `Depends: openssl` on this base image, which must stay legitimate OS substrate).
- `packaging/deb/build.sh` / `packaging/rpm/build.sh`: removed `--tls-backend native|openssl-adapter` and the `tardi version`-based backend inference. The packaged binary's native identity is now always proven with `scripts/audit-release-binary.sh` — self-audited when the binary is host-executable, or via a new `--audit-inventory` flag (a pre-generated inventory JSON matched to the binary by SHA-256) for cross-architecture packaging where the artifact can't run on the packaging host. Neither builder can emit an `openssl`/`libssl` runtime dependency any more.
- `packaging/rpm/tardigrade.spec`: removed the conditional `Requires: openssl-libs` block outright — there is no longer a backend that needs it.
- `scripts/audit-release-binary.sh`: inventory JSON gains a `binary_sha256` field so a caller-supplied `--audit-inventory` can be cryptographically bound to the exact artifact rather than trusted blindly.
- Regression coverage: `scripts/test-deb-package.sh` / `scripts/test-rpm-package.sh` now assert `--tls-backend openssl-adapter` is rejected, exercise the `--audit-inventory` cross-architecture path (including a mismatched-SHA rejection), audit the exact binary the package installs, and start it against its packaged config for a real `/health` request — not just `tardi version`. Both also stop pre-installing `libssl3`/`openssl-devel`/`openssl-libs` into their smoke-test containers, since installing them ahead of time would mask a real regression.
- `scripts/test-rpm-package.sh`: also drops the Rocky/RHEL 9 glibc-version floor (`-Dtarget=$arch-linux-gnu.2.34`). It existed because the old OpenSSL adapter's `libssl.so` pulled in glibc 2.34's reversioned pthread symbols before Zig's default floor knew about them; confirmed by testing that the native build (which links no OpenSSL) no longer needs it.
- Docs (`packaging/README.md`, `docs/DEPLOYMENT.md`, `docs/TLS_DEPENDENCY_POLICY.md`) and `CHANGELOG.md` updated to match; also fixed a stale `--profile native` reference in `packaging/README.md` (the profile name is `general`).
- Small, related fix folded in: `scripts/update-homebrew-formula.sh`'s `validate_native_inventory()` still compared a release inventory's `.profile`/`.reported_profile` against the retired `"native"` name instead of `"general"` (a #654 rename this one check missed), which would have rejected every real release inventory; fixed, along with the stale `test-homebrew-tap-sync.sh` fixture that was masking it. This doesn't take Homebrew publication ownership away from #466 — it's a one-field vocabulary fix so the existing #466-owned tooling reads `#649`'s actual profile name.

## Test plan
- [x] `./scripts/audit-dependencies.sh` passes
- [x] `zig build -Doptimize=ReleaseFast` succeeds; `tardi version` reports `tls-profile=general, tls-backend=native`
- [x] `./scripts/audit-release-binary.sh --binary zig-out/bin/tardi --profile general --output …` passes and emits `binary_sha256`
- [x] `bash -n` on every modified shell script
- [x] Manually exercised the full DEB/RPM build → `--audit-inventory` cross-arch → install → installed-binary audit → real HTTP request flow, and the Docker build/runtime `apt-mark` checks (including the regression case), in real containers since this sandbox can't run the actual CI jobs
- [x] `packaging-smoke` CI job (Docker/DEB/RPM smoke) green on this PR
- [x] Two rounds of review feedback addressed and confirmed by a follow-up review

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)
