### PR TITLE
fix: match update-homebrew-formula.sh's native-inventory check to the general profile name

### DIFF
--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -155,8 +155,8 @@ validate_native_inventory() {
 
     gh release download "$TAG" --repo "$REPO" --pattern "$inventory_asset" --dir "$tmpdir" --clobber
     inventory_path="$tmpdir/$inventory_asset"
-    if [ "$(jq -r '.profile' "$inventory_path")" != "native" ] ||
-        [ "$(jq -r '.reported_profile' "$inventory_path")" != "native" ] ||
+    if [ "$(jq -r '.profile' "$inventory_path")" != "general" ] ||
+        [ "$(jq -r '.reported_profile' "$inventory_path")" != "general" ] ||
         [ "$(jq -r '.reported_backend' "$inventory_path")" != "native" ] ||
         [ "$(jq -r '.links_openssl' "$inventory_path")" != "false" ] ||
         [ "$(jq -r '.status' "$inventory_path")" != "pass" ]; then


### PR DESCRIPTION
## Summary
- `validate_native_inventory()` in `scripts/update-homebrew-formula.sh` still checked the dependency-inventory JSON's `.profile`/`.reported_profile` fields against the literal string `"native"`.
- #654 retired the OpenSSL adapter and merged the native general-purpose profile back into the `general` tag — there is no longer a profile named `native` (the TLS profile enum in `build.zig` is `general | appliance`). Release inventories are generated with `scripts/audit-release-binary.sh --profile general`, so a real release inventory's `.profile`/`.reported_profile` are `"general"`, not `"native"`.
- `scripts/test-homebrew-formula.sh` and `scripts/test-homebrew-release-formula.sh` were correctly updated for this rename in #654, but this one check in `update-homebrew-formula.sh` was missed, so it would reject every real release inventory going forward, blocking Homebrew formula generation (owned by #466) once a native release actually exists.
- `.reported_backend` is left checking `"native"`, which is still correct — the backend name didn't change, only the profile name did.

## Test plan
- [x] `bash -n scripts/update-homebrew-formula.sh`
- [ ] `Homebrew formula smoke` CI job (this repo doesn't have a native release yet to exercise `--tag` mode against, so this was previously untested against real inventory data; the fixture-mode smoke tests don't hit this code path since `validate_native_inventory` returns early when `$TAG` is unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)