### PR TITLE
chore(release): cut 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes to Tardigrade are documented here.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-24
+
 ### Added
 - **Production dependency boundary enforcement (#651)** — production source,
   build, package, container, and binary audits now enforce the project-wide


### PR DESCRIPTION
## Summary
- Adds the `## [0.6.0] - 2026-08-24` heading to `CHANGELOG.md`, which is the sole source `scripts/release-metadata.sh` reads for the release version/tag.
- This is the first release cut after the native-only production cutover (#649, #650, #651) — `v0.6.0` is the intended next stable release per #634/#652, no RC/pre-release process.
- Merging this once CI is green will produce a push-triggered CI run on `main`; `release.yml`'s `workflow_run` trigger fires on that run's success and builds/publishes the real `v0.6.0` release artifacts.

## Test plan
- [x] `./scripts/release-metadata.sh version` → `0.6.0`
- [x] `./scripts/release-metadata.sh tag` → `v0.6.0`
- [ ] CI green on this PR
- [ ] Post-merge CI on `main` green → triggers `release.yml` → v0.6.0 published
- [ ] Independent validation of published artifacts (tracked in #652)

Part of the #652 / #634 closeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)