### PR TITLE
test: make reload-under-load coverage deterministic

### DIFF
--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -15465,31 +15465,72 @@ test "reload while serving short static requests drops no in-flight request (#17
     , .{root_a});
     defer allocator.free(config_a);
 
-    var tardigrade = try TardigradeProcess.start(allocator, .{ .config_text = config_a });
+    // This test intentionally drives one localhost client as fast as
+    // possible. Rate limiting is a separate concern: leaving the
+    // harness default enabled makes a sufficiently fast runner receive
+    // legitimate 429s and misclassify them as reload request loss.
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = config_a,
+        .rate_limit_rps = "0",
+    });
     defer tardigrade.stop();
 
     const Hammer = struct {
         port: u16,
         stop_flag: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+        site_a: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+        site_b: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
         ok: usize = 0,
         fail: usize = 0,
+
         fn run(self: *@This()) void {
             const a = std.heap.page_allocator;
             while (!self.stop_flag.load(.acquire)) {
-                var resp = sendRequest(a, self.port, .{ .method = "GET", .path = "/index.html", .body = null, .headers = &.{} }) catch {
+                var resp = sendRequest(a, self.port, .{
+                    .method = "GET",
+                    .path = "/index.html",
+                    .body = null,
+                    .headers = &.{},
+                }) catch {
                     self.fail += 1;
                     continue;
                 };
                 defer resp.deinit();
-                if (resp.status_code == 200) self.ok += 1 else self.fail += 1;
+
+                if (resp.status_code != 200) {
+                    self.fail += 1;
+                    continue;
+                }
+                if (std.mem.find(u8, resp.body, "site-A") != null) {
+                    self.ok += 1;
+                    _ = self.site_a.fetchAdd(1, .acq_rel);
+                } else if (std.mem.find(u8, resp.body, "site-B") != null) {
+                    self.ok += 1;
+                    _ = self.site_b.fetchAdd(1, .acq_rel);
+                } else {
+                    self.fail += 1;
+                }
             }
         }
     };
     var hammer = Hammer{ .port = tardigrade.port };
     const thread = try std.Thread.spawn(.{}, Hammer.run, .{&hammer});
+    var thread_joined = false;
+    defer {
+        if (!thread_joined) {
+            hammer.stop_flag.store(true, .release);
+            thread.join();
+        }
+    }
 
-    // Let requests flow, reload to root B mid-stream, let more flow.
-    compat.sleepNs(150 * std.time.ns_per_ms);
+    // Synchronize on actual traffic instead of assuming a fixed amount
+    // of wall-clock time is enough for a particular CI runner.
+    var attempts: usize = 0;
+    while (hammer.site_a.load(.acquire) < 10 and attempts < 200) : (attempts += 1) {
+        compat.sleepNs(10 * std.time.ns_per_ms);
+    }
+    try std.testing.expect(hammer.site_a.load(.acquire) >= 10);
+
     const config_b = try std.fmt.allocPrint(allocator,
         \\location / {{
         \\    root {s};
@@ -15499,10 +15540,16 @@ test "reload while serving short static requests drops no in-flight request (#17
     defer allocator.free(config_b);
     try tardigrade.rewriteConfig(config_b);
     tardigrade.sendSignal(std.posix.SIG.HUP);
-    compat.sleepNs(300 * std.time.ns_per_ms);
+
+    attempts = 0;
+    while (hammer.site_b.load(.acquire) < 10 and attempts < 200) : (attempts += 1) {
+        compat.sleepNs(10 * std.time.ns_per_ms);
+    }
+    try std.testing.expect(hammer.site_b.load(.acquire) >= 10);
 
     hammer.stop_flag.store(true, .release);
     thread.join();
+    thread_joined = true;
 
     // The core guarantee: every request served across the reload succeeded.
     try std.testing.expect(hammer.ok > 0);


### PR DESCRIPTION
## Summary

Fixes the flaky `reload while serving short static requests drops no in-flight request (#170)` integration test seen in Actions run 32789041958 / job 97626803052.

The failing run reported `expected 0, found 112`, but the test was not isolating reload behavior from the integration harness's default rate limiter.

## Root cause

`TardigradeOptions` enables a `1000 req/s` rate limit with a burst of `1000` by default. This test deliberately hammers the server as fast as a localhost runner can go and treats **every non-200 response** as a dropped reload request.

On a sufficiently fast CI runner, the single `127.0.0.1` token bucket is exhausted and valid `429 Too Many Requests` responses are counted as reload failures. Reload also recreates the limiter, so the exact failure count depends on machine throughput and the test's fixed 150 ms / 300 ms timing windows. That makes the test hardware-speed-dependent even when reload itself is correct.

## Fix

- Disable rate limiting **only for this test** with `rate_limit_rps = "0"`, so it measures reload continuity rather than rate limiting.
- Classify successful hammer responses as `site-A` or `site-B` instead of treating any 200 as sufficient.
- Replace the fixed pre/post-reload sleeps with bounded synchronization on actually observing traffic from both configurations.
- Ensure the hammer thread is stopped and joined even if an intermediate assertion fails.
- Preserve the existing zero-failure assertion and post-reload config/status checks.

No production behavior changes.

## Validation

- `git diff --check` passes for the generated source diff.
- Branch diff against `main` is one commit touching only `tests/integration.zig` (+53/-6).
- CI should exercise the repaired integration test across the normal profile matrix.

Refs #170
