### PR TITLE
fix(test): retry connection-level errors in the native H2 upstream test

### DIFF
--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -18300,12 +18300,25 @@ test "native upstream h2 (best-effort, not CI-gated): negotiates h2 and complete
     // real failure.
     var attempt: usize = 0;
     var response: HttpResponse = while (attempt < 20) : (attempt += 1) {
-        var candidate = try sendRequestWithTimeout(allocator, tardigrade.port, .{
+        var candidate = sendRequestWithTimeout(allocator, tardigrade.port, .{
             .method = "GET",
             .path = "/secure/h2-upstream",
             .body = null,
             .headers = &.{},
-        }, 10_000);
+        }, 10_000) catch |err| switch (err) {
+            // The upstream listener's just-completed TLS readiness probe can
+            // still be tearing down its prior connection when an attempt
+            // lands, producing a raw connection-level failure instead of a
+            // clean response with a non-200 status. Retry those exactly like
+            // a non-200 -- previously these propagated straight out of the
+            // retry loop via `try`, so the very first race lost the whole
+            // test instead of being absorbed by the retry budget below.
+            error.InvalidHttpResponse, error.ConnectionResetByPeer, error.SocketUnconnected => {
+                compat.sleepNs(100 * std.time.ns_per_ms);
+                continue;
+            },
+            else => return err,
+        };
         if (candidate.status_code == 200) break candidate;
         candidate.deinit();
         compat.sleepNs(100 * std.time.ns_per_ms);


### PR DESCRIPTION
## Summary
- Found while cutting the v0.6.0 release: the push-to-main-only `Integration tests` CI job (which `release.yml`'s `workflow_run` trigger is watching) failed on `native upstream h2 (best-effort, not CI-gated): negotiates h2 and completes a real proxied request over H2` with `error.InvalidHttpResponse` from `readHttpResponseWithTimeout`.
- This job only runs on `push` to `main` (`if: github.event_name == 'push' && github.ref == 'refs/heads/main'`), so it's invisible to normal PR CI — it only surfaces on the exact run gating a release.
- Root cause: the test already retries up to 20 times on a non-200 response to absorb a documented race against the upstream listener's just-completed TLS readiness probe, but `sendRequestWithTimeout` was called with `try`, so a connection-level failure from that same race (`InvalidHttpResponse`/`ConnectionResetByPeer`/`SocketUnconnected`) propagated straight out of the loop on the very first occurrence instead of being retried like a non-200 would be.
- Fix: catch those three specific transient errors and retry; anything else still propagates as a real failure.

## Test plan
- [x] `zig build test-integration -Dintegration-test-filter="native upstream h2"` passes in isolation
- [x] `zig build test-integration` run locally — the 3 unrelated `error.CurlFailed` bearclaw failures are pre-existing local-sandbox `curl` subprocess restrictions, not from this change
- [ ] CI green on this PR

Blocks getting a green push-to-main CI run to trigger the v0.6.0 release build (#652 / #634 closeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)