### PR TITLE
fix(release): pin a portable CPU baseline for release/Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,25 @@ jobs:
           benchmarks/competitive/netem-impair.sh
           benchmarks/test-h3-benchmark.sh
 
+      # A native `zig build` with no explicit -Dcpu embeds the exact CPU
+      # features of whatever host builds it. release.yml and the Dockerfile
+      # both build natively (host arch == shipped target arch) and publish
+      # the result for users to run on arbitrary other hardware, so both
+      # must pin -Dcpu=baseline or the published binary/image can crash with
+      # Illegal Instruction on real hardware that lacks the build host's
+      # specific CPU features (confirmed on real non-CI x86_64/aarch64
+      # hardware while validating v0.6.0's published release).
+      - name: Verify release/Docker builds pin a portable CPU baseline
+        run: |
+          grep -qE -- '-Dcpu=baseline' .github/workflows/release.yml || {
+            echo "release.yml's release binary build must pin -Dcpu=baseline (see Dockerfile for why)" >&2
+            exit 1
+          }
+          grep -qE -- '-Dcpu=baseline' Dockerfile || {
+            echo "Dockerfile's zig build must pin -Dcpu=baseline (see release.yml for why)" >&2
+            exit 1
+          }
+
       - name: Validate Homebrew formula renderer
         run: |
           tmpdir="$(mktemp -d)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,14 @@ jobs:
       - name: Build native release binary
         env:
           VERSION: ${{ needs.prepare-release.outputs.version }}
-        run: zig build -Doptimize=ReleaseFast "-Dversion=$VERSION"
+        # -Dcpu=baseline: this is a native build (host arch == target arch),
+        # which by default has Zig auto-detect and embed the exact CPU
+        # features of this specific runner. A published release binary has
+        # to run on whatever real hardware a user has -- not just this
+        # runner's microarchitecture -- so pin the portable baseline
+        # instruction set explicitly rather than inheriting whatever this
+        # host happens to support.
+        run: zig build -Doptimize=ReleaseFast -Dcpu=baseline "-Dversion=$VERSION"
 
       - name: Verify macOS binary architecture
         if: runner.os == 'macOS'

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,12 @@ RUN sh ./scripts/install-zig.sh 0.16.0 /opt/zig \
 
 # Default "general" TLS profile: pure-Zig native (#649) — no OpenSSL/libcrypto
 # build dependency for Tardigrade itself (see docs/TLS_DEPENDENCY_POLICY.md).
-RUN zig build -Doptimize=ReleaseFast
+# -Dcpu=baseline: this is a native build (BuildKit runs it on whatever host
+# arch matches the image target), and Zig's default native build embeds the
+# exact CPU features of that build host. A published image has to run on
+# whatever host a user's container runtime lands on, not just the builder's
+# microarchitecture, so pin the portable baseline explicitly.
+RUN zig build -Doptimize=ReleaseFast -Dcpu=baseline
 
 # ── Runtime ───────────────────────────────────────────────────────────────────
 FROM debian@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241 AS runtime


### PR DESCRIPTION
## Summary

Found while independently validating v0.6.0's public artifacts (#652): the published `tardigrade-linux-x86_64.tar.gz` and `tardigrade-linux-aarch64.tar.gz` binaries crash with `Illegal instruction` (SIGILL) on real hardware other than the exact GitHub Actions runner that built them.

**Root cause**: `release.yml` and the `Dockerfile` both build natively (host arch == shipped target arch) via plain `zig build -Doptimize=ReleaseFast`. With no explicit `-Dcpu`, Zig's native build auto-detects and embeds the build host's exact CPU feature set. That's fine for a binary that only ever runs where it was built, but wrong for a release artifact/image published for users to run on arbitrary other hardware of the same architecture.

**Confirmed on real (non-emulated) hardware, not speculation:**
- Copied the published v0.6.0 `linux-x86_64` archive's `tardi` binary to a real x86_64 machine: SIGILL, exit 132.
- Cross-compiled the *identical* source (verified byte-identical tree to the released commit `3633aba3`) with `-Dtarget=x86_64-linux -Dcpu=baseline`: runs correctly on that same machine — `tardi version` and a real HTTP request both succeed.
- Same experiment for `aarch64-linux` against a native (non-emulated) Debian ARM64 Docker container on Apple Silicon: SIGILL without the fix, clean run with `-Dcpu=baseline`.
- Ran the repo's own `scripts/test-docker-image.sh` end to end on real Linux with the Dockerfile fix applied: passes, including the native-only linkage audit, `/health` check, reload, and graceful stop.

**Fix**: add `-Dcpu=baseline` to both build invocations, plus a CI lint check (`Verify release/Docker builds pin a portable CPU baseline`) asserting both files keep the flag so this can't silently regress.

## Test plan
- [x] Real x86_64 hardware: published binary SIGILLs, baseline-rebuilt binary runs and serves a real request
- [x] Real (non-emulated) ARM64 Docker: published-equivalent binary SIGILLs, baseline-rebuilt binary runs and serves a real request
- [x] `scripts/test-docker-image.sh` passes end to end on real Linux with the Dockerfile fix
- [ ] CI green on this PR

v0.6.0 stays published as-is; this becomes v0.6.1 once merged and released, per the defect-handling guidance in #652.

🤖 Generated with [Claude Code](https://claude.com/claude-code)