### PR TITLE
chore(release): cut 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable user-facing changes to Tardigrade are documented here.
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-25
+
+### Fixed
+- **Release/Docker builds now pin a portable CPU baseline** — the published
+  `v0.6.0` `linux-x86_64`/`linux-aarch64` archives and the Docker image were
+  built with a plain native `zig build`, which embeds the exact CPU feature
+  set of the GitHub Actions runner that built them rather than a portable
+  baseline. Confirmed on real (non-emulated) x86_64 and ARM64 hardware: the
+  `v0.6.0` binaries crash with `Illegal instruction` on hardware that
+  doesn't match the build runner's specific microarchitecture. `release.yml`
+  and the `Dockerfile` now build with `-Dcpu=baseline`, and CI asserts both
+  keep the flag.
+
 ## [0.6.0] - 2026-08-24
 
 ### Added


### PR DESCRIPTION
## Summary
- Adds the `## [0.6.1] - 2026-08-25` heading to `CHANGELOG.md`, the source `scripts/release-metadata.sh` reads for the release version/tag.
- Patch release for the CPU-baseline portability fix in #663, found while independently validating v0.6.0's published artifacts (#652). v0.6.0 stays published as-is per the defect-handling guidance — this is the normal 0.6.x patch path.
- Merging this once CI is green triggers a push-to-main CI run; `release.yml`'s `workflow_run` trigger fires on that run's success and builds/publishes the real `v0.6.1` release artifacts, this time with the portable CPU baseline fix included.

## Test plan
- [x] `./scripts/release-metadata.sh version` → `0.6.1`
- [x] `./scripts/release-metadata.sh tag` → `v0.6.1`
- [ ] CI green on this PR
- [ ] Post-merge CI on `main` green → triggers `release.yml` → v0.6.1 published

Part of the #652 / #634 closeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)