### PR TITLE
fix(release): pin a portable glibc floor for Linux release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,16 @@ jobs:
             exit 1
           }
 
+      # The Docker image bundles its own glibc (from its base image), so it
+      # doesn't need this -- only the native archive/DEB/RPM build, which
+      # runs on a user's own host glibc.
+      - name: Verify release Linux builds pin a portable glibc floor
+        run: |
+          grep -qE -- 'linux-gnu\.2\.[0-9]+' .github/workflows/release.yml || {
+            echo "release.yml's Linux matrix entries must pin an explicit -Dtarget=<arch>-linux-gnu.<version> glibc floor (confirmed v0.6.1's plain native build required glibc newer than Ubuntu 22.04 LTS/RHEL9 ship)" >&2
+            exit 1
+          }
+
       - name: Validate Homebrew formula renderer
         run: |
           tmpdir="$(mktemp -d)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,17 +114,28 @@ jobs:
             deb_arch: amd64
             rpm_arch: x86_64
             linux_packages: true
+            # Pin a portable glibc floor: a plain native build on this
+            # runner links against symbols requiring the runner's full
+            # glibc version, which is newer than what many still-supported
+            # distros (e.g. Ubuntu 22.04 LTS glibc 2.35, RHEL9/Rocky9/Alma9
+            # glibc 2.34) ship, so the published archive/DEB/RPM fail to
+            # even start there. 2.28 matches the long-established
+            # manylinux2014/RHEL8 portable-Linux-binary floor.
+            zig_target: x86_64-linux-gnu.2.28
           - os: ubuntu-24.04-arm
             archive_name: tardigrade-linux-aarch64
             deb_arch: arm64
             rpm_arch: aarch64
             linux_packages: true
+            zig_target: aarch64-linux-gnu.2.28
           - os: macos-15-intel
             archive_name: tardigrade-darwin-x86_64
             linux_packages: false
+            zig_target: ""
           - os: macos-15
             archive_name: tardigrade-darwin-arm64
             linux_packages: false
+            zig_target: ""
 
     steps:
       - name: Checkout release commit
@@ -170,6 +181,7 @@ jobs:
       - name: Build native release binary
         env:
           VERSION: ${{ needs.prepare-release.outputs.version }}
+          ZIG_TARGET: ${{ matrix.zig_target }}
         # -Dcpu=baseline: this is a native build (host arch == target arch),
         # which by default has Zig auto-detect and embed the exact CPU
         # features of this specific runner. A published release binary has
@@ -177,7 +189,20 @@ jobs:
         # runner's microarchitecture -- so pin the portable baseline
         # instruction set explicitly rather than inheriting whatever this
         # host happens to support.
-        run: zig build -Doptimize=ReleaseFast -Dcpu=baseline "-Dversion=$VERSION"
+        #
+        # -Dtarget=<arch>-linux-gnu.2.28 (Linux only): a plain native build
+        # also links against this runner's full glibc symbol versions,
+        # which are newer than many still-supported distros ship (Ubuntu
+        # 22.04 LTS, RHEL9/Rocky9/Alma9), so the published archive/DEB/RPM
+        # fail to even start there. Pin the portable glibc floor explicitly;
+        # matrix.zig_target is empty on Darwin, which has no equivalent
+        # versioned-libc concern.
+        run: |
+          if [ -n "$ZIG_TARGET" ]; then
+            zig build -Doptimize=ReleaseFast -Dcpu=baseline "-Dtarget=$ZIG_TARGET" "-Dversion=$VERSION"
+          else
+            zig build -Doptimize=ReleaseFast -Dcpu=baseline "-Dversion=$VERSION"
+          fi
 
       - name: Verify macOS binary architecture
         if: runner.os == 'macOS'


### PR DESCRIPTION
## Summary

Found while independently validating v0.6.1's Homebrew path (#652): the published `tardigrade-linux-x86_64.tar.gz` binary requires `GLIBC_2.36`, newer than what several still-supported distros ship — confirmed failing to even start (dynamic linker error) on both **Ubuntu 22.04 LTS** (glibc 2.35 — including inside official Homebrew's own `homebrew/brew` Docker image) and **Rocky Linux 9** (glibc 2.34).

Same root cause pattern as the CPU-baseline fix in v0.6.1 (#663): `release.yml`'s "Build native release binary" step is a native build (host == target) with no explicit glibc floor, so it links against whatever full symbol-version set the specific GitHub Actions runner's glibc happens to provide.

**Docker doesn't need this** — the image bundles its own glibc (Debian bookworm's 2.36 already satisfies the plain-native build), so this only touches the archive/DEB/RPM build path, which runs against a user's own host glibc.

**Fix**: `-Dtarget=<arch>-linux-gnu.2.28` on the two Linux matrix entries (Darwin entries get an empty `matrix.zig_target` and build native as before, unaffected). 2.28 matches the long-established manylinux2014/RHEL8 portable-Linux-binary floor.

## Test plan
- [x] x86_64 cross-compiled with the fix: runs on Ubuntu 22.04 (official `homebrew/brew` container) — real hardware, no emulation
- [x] x86_64 cross-compiled with the fix: runs on Rocky Linux 9 — real hardware, no emulation
- [x] aarch64 cross-compiled with the fix: runs on native (non-emulated) ARM64 Ubuntu 22.04
- [x] Extended the CI lint check from #663 to assert release.yml pins an explicit glibc floor
- [ ] CI green on this PR

v0.6.1 stays published as-is; this becomes v0.6.2 once merged and released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)