### PR TITLE
chore(release): cut 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable user-facing changes to Tardigrade are documented here.
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-08-25
+
+### Fixed
+- **Linux release/DEB/RPM builds now pin a portable glibc floor** — the
+  published `v0.6.1` `linux-x86_64`/`linux-aarch64` archives required
+  `GLIBC_2.36`, newer than several still-supported distros ship. Confirmed
+  on real hardware: the binaries failed to start on Ubuntu 22.04 LTS (glibc
+  2.35, including inside official Homebrew's own `homebrew/brew` container)
+  and Rocky Linux 9 (glibc 2.34). `release.yml`'s Linux matrix entries now
+  build with `-Dtarget=<arch>-linux-gnu.2.28`, matching the established
+  manylinux2014/RHEL8 portable-Linux-binary floor; Darwin builds and the
+  Docker image (which bundles its own glibc) are unaffected. CI now asserts
+  the floor stays pinned.
+
 ## [0.6.1] - 2026-08-25
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Adds the `## [0.6.2] - 2026-08-25` heading to `CHANGELOG.md`.
- Patch release for the glibc-floor portability fix in #665, found while independently validating v0.6.1's Homebrew tap path (#652). v0.6.1 stays published as-is.
- Merging this once CI is green triggers a push-to-main CI run; `release.yml` fires on that run's success and builds/publishes the real `v0.6.2` release artifacts with both the CPU-baseline and glibc-floor fixes included.

## Test plan
- [x] `./scripts/release-metadata.sh version` → `0.6.2`
- [x] `./scripts/release-metadata.sh tag` → `v0.6.2`
- [ ] CI green on this PR
- [ ] Post-merge CI on `main` green → triggers `release.yml` → v0.6.2 published

Part of the #652 / #634 closeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)