### PR TITLE
fix(http): send Connection: close on the response that hits max_requests_per_connection

### DIFF
--- a/src/edge_gateway.zig
+++ b/src/edge_gateway.zig
@@ -1269,8 +1269,15 @@ fn serveOneRequestWithConfig(
         header_timeout_ms;
     setConnTimeouts(conn, header_timeout_ms, write_timeout_ms);
 
+    const max_requests_per_connection = cfg.max_requests_per_connection;
+    // This is the last request the server will allow on this physical
+    // connection: handleConnection must send `Connection: close` on its
+    // response rather than `keep-alive`, or the client will reuse a
+    // connection the server is about to tear down and lose its next request.
+    const is_last_allowed_request = max_requests_per_connection > 0 and served.* + 1 >= max_requests_per_connection;
+
     var keep_alive = false;
-    handleConnection(conn, session, cfg, ctx.state, &keep_alive, connection_ip, enable_proxy_protocol) catch |err| {
+    handleConnection(conn, session, cfg, ctx.state, &keep_alive, connection_ip, enable_proxy_protocol, is_last_allowed_request) catch |err| {
         if (isBenignDisconnect(err)) {
             ctx.state.logger.debug(null, "keepalive connection closed by peer: {}", .{err});
         } else {
@@ -1279,7 +1286,6 @@ fn serveOneRequestWithConfig(
         return .close;
     };
     served.* += 1;
-    const max_requests_per_connection = cfg.max_requests_per_connection;
 
     if (!keep_alive or http.shutdown.isShutdownRequested()) return .close;
     if (max_requests_per_connection > 0 and served.* >= max_requests_per_connection) return .close;
@@ -3731,7 +3737,7 @@ fn setConnTimeouts(conn: anytype, read_timeout_ms: u32, write_timeout_ms: u32) v
     }
 }
 
-fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge_config.EdgeConfig, state: *GatewayState, keep_alive_out: *bool, connection_ip: []const u8, enable_proxy_protocol: bool) !void {
+fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge_config.EdgeConfig, state: *GatewayState, keep_alive_out: *bool, connection_ip: []const u8, enable_proxy_protocol: bool, is_last_allowed_request: bool) !void {
     var keep_alive = false;
     keep_alive_out.* = false;
     defer keep_alive_out.* = keep_alive;
@@ -3881,6 +3887,9 @@ fn handleConnection(conn: anytype, session: *ConnectionSession, cfg: *const edge
     keep_alive = request.keepAlive();
     if (streaming_request_body != null) keep_alive = false;
     if (http.shutdown.isShutdownRequested()) keep_alive = false;
+    // Tell the client this is the last response on this connection (RFC
+    // 7230 §6.6) instead of closing the socket after promising keep-alive.
+    if (is_last_allowed_request) keep_alive = false;
 
     // --- Correlation ID ---
     const correlation_id = try http.correlation.fromHeadersOrGenerate(allocator, &request.headers);

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -16324,9 +16324,10 @@ test "max_requests_per_connection sends Connection: close on the response that h
 
     // The server closed after the limiting response — the client sees a clean
     // EOF on a further read rather than the connection silently swallowing
-    // the next request.
+    // the next request. Do not swallow read errors here: a stalled or reset
+    // connection must fail this assertion, not be mistaken for a clean FIN.
     var probe: [1]u8 = undefined;
-    const n = stream.read(&probe) catch 0;
+    const n = try stream.read(&probe);
     try std.testing.expectEqual(@as(usize, 0), n);
 }
 

--- a/tests/integration.zig
+++ b/tests/integration.zig
@@ -16269,6 +16269,67 @@ test "idle keepalive connections parked off the worker pool do not starve active
     }
 }
 
+test "max_requests_per_connection sends Connection: close on the response that hits the limit (#682)" {
+    // Before the fix, the server picked keep_alive purely from the request's
+    // own Connection header/version, so the response that tripped
+    // max_requests_per_connection still went out with `Connection: keep-alive`
+    // even though the caller was about to close the socket right after. The
+    // client would then reuse the connection and lose its next request
+    // (RemoteDisconnected) instead of seeing a standard `Connection: close`.
+    const allocator = std.testing.allocator;
+
+    var fixture = try GenericFixtureDir.create(allocator, "max-requests-per-connection");
+    defer fixture.deinit();
+    try fixture.writeRel("public/index.html", "ok\n");
+    const public_abs = try fixture.joinAbs("public");
+    defer allocator.free(public_abs);
+
+    const config_text = try std.fmt.allocPrint(allocator,
+        \\location / {{
+        \\    root {s};
+        \\    try_files $uri /index.html;
+        \\}}
+    , .{public_abs});
+    defer allocator.free(config_text);
+
+    const max_requests = 3;
+    var tardigrade = try TardigradeProcess.start(allocator, .{
+        .config_text = config_text,
+        .extra_env = &.{
+            .{ .name = "TARDIGRADE_MAX_REQUESTS_PER_CONNECTION", .value = "3" },
+            .{ .name = "TARDIGRADE_KEEP_ALIVE_TIMEOUT_MS", .value = "30000" },
+        },
+    });
+    defer tardigrade.stop();
+
+    var stream = try compat.tcpConnectToHost(allocator, test_host, tardigrade.port);
+    defer stream.close();
+    try setStreamTimeouts(&stream, 5_000);
+
+    for (0..max_requests) |i| {
+        try sendKeepAliveGet(&stream, allocator, tardigrade.port, "/index.html");
+        var resp = try readHttpResponse(allocator, stream);
+        defer resp.deinit();
+        try std.testing.expectEqual(@as(u16, 200), resp.status_code);
+
+        const connection_header = resp.header("connection") orelse "";
+        if (i + 1 < max_requests) {
+            try std.testing.expect(std.ascii.eqlIgnoreCase(connection_header, "keep-alive"));
+        } else {
+            // This is the max_requests_per_connection-th response: the server
+            // is about to close the physical connection, so it must say so.
+            try std.testing.expect(std.ascii.eqlIgnoreCase(connection_header, "close"));
+        }
+    }
+
+    // The server closed after the limiting response — the client sees a clean
+    // EOF on a further read rather than the connection silently swallowing
+    // the next request.
+    var probe: [1]u8 = undefined;
+    const n = stream.read(&probe) catch 0;
+    try std.testing.expectEqual(@as(usize, 0), n);
+}
+
 // ---------------------------------------------------------------------------
 // Failure-mode / chaos harness (#169)
 //


### PR DESCRIPTION
## Summary
- `handleConnection` decided `Connection: keep-alive` vs `close` purely from the request's own header/HTTP version, with no idea how many requests had already been served on the physical connection. When a response hit `max_requests_per_connection`, the caller (`serveOneRequestWithConfig`) closed the socket right after — but the response itself still went out promising `keep-alive`, so the client believed it could reuse the (now-closed) connection and got `RemoteDisconnected` on its next request instead of a clean `Connection: close`.
- `serveOneRequestWithConfig` now computes whether the in-flight request is the last one this connection will be allowed to serve (`served + 1 >= max_requests_per_connection`) and passes that down into `handleConnection`, which forces `keep_alive = false` for that response so the client sees a standard `Connection: close` — matching how nginx/HAProxy/Caddy handle their own `keepalive_requests`-equivalent settings.

## Test plan
- [x] Added `tests/integration.zig`: `max_requests_per_connection sends Connection: close on the response that hits the limit (#682)` — sets `TARDIGRADE_MAX_REQUESTS_PER_CONNECTION=3`, sends 3 keep-alive requests on one socket, asserts the first two say `keep-alive`, the third says `close`, and the socket then reads a clean EOF.
- [x] Verified the new test fails without the fix (`RemoteDisconnected`-style assertion failure on the `Connection: close` check) and passes with it.
- [x] `zig build` and `zig build test` pass.

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)