### PR TITLE
Add public Homebrew tap smoke

### DIFF
--- a/.github/workflows/public-homebrew-smoke.yml
+++ b/.github/workflows/public-homebrew-smoke.yml
@@ -2,6 +2,11 @@ name: Public Homebrew Smoke
 
 on:
   workflow_dispatch:
+    inputs:
+      expected_version:
+        description: "Expected public Tardigrade release version, with or without leading v. Defaults to the latest stable GitHub release."
+        required: false
+        type: string
   schedule:
     - cron: "37 11 * * 1"
 
@@ -60,6 +65,7 @@ jobs:
       - name: Smoke public Homebrew tap install
         env:
           INSTALL_MODE: ${{ matrix.install_mode }}
+          EXPECTED_VERSION: ${{ inputs.expected_version || '' }}
         run: |
           set -euo pipefail
           if [ "$RUNNER_OS" = Linux ]; then

--- a/.github/workflows/public-homebrew-smoke.yml
+++ b/.github/workflows/public-homebrew-smoke.yml
@@ -1,0 +1,68 @@
+name: Public Homebrew Smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "37 11 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-homebrew-smoke-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  public-homebrew-smoke:
+    name: Public Homebrew smoke (${{ matrix.os }}, ${{ matrix.install_mode }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            install_mode: qualified
+          - os: macos-15
+            install_mode: tap-short
+          - os: macos-15-intel
+            install_mode: qualified
+          - os: macos-15-intel
+            install_mode: tap-short
+          - os: ubuntu-latest
+            install_mode: qualified
+          - os: ubuntu-latest
+            install_mode: tap-short
+          - os: ubuntu-24.04-arm
+            install_mode: qualified
+          - os: ubuntu-24.04-arm
+            install_mode: tap-short
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y build-essential curl file git procps ruby
+
+      - name: Install Linuxbrew
+        if: runner.os == 'Linux'
+        env:
+          NONINTERACTIVE: "1"
+        run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          brew --version
+
+      - name: Smoke public Homebrew tap install
+        env:
+          INSTALL_MODE: ${{ matrix.install_mode }}
+        run: |
+          set -euo pipefail
+          if [ "$RUNNER_OS" = Linux ]; then
+            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          fi
+          ./scripts/test-public-homebrew-tap.sh --install-mode "$INSTALL_MODE"

--- a/.github/workflows/public-homebrew-smoke.yml
+++ b/.github/workflows/public-homebrew-smoke.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           INSTALL_MODE: ${{ matrix.install_mode }}
           EXPECTED_VERSION: ${{ inputs.expected_version || '' }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           if [ "$RUNNER_OS" = Linux ]; then

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -53,9 +53,10 @@ Use this checklist before tagging and distributing a Tardigrade release.
       `homebrew-tap/README.md` is tap-owned; update it only when public
       support policy or install instructions change.
 - [ ] After the public tap update is pushed, run the black-box public-tap smoke
-      with `./scripts/test-public-homebrew-tap.sh --install-mode qualified` and
-      `./scripts/test-public-homebrew-tap.sh --install-mode tap-short`, or run
-      the manual `Public Homebrew Smoke` workflow.
+      with `./scripts/test-public-homebrew-tap.sh --install-mode qualified --expected-version X.Y.Z`
+      and `./scripts/test-public-homebrew-tap.sh --install-mode tap-short --expected-version X.Y.Z`,
+      or run the manual `Public Homebrew Smoke` workflow with the expected
+      version input.
 - [ ] Verify both Darwin archives have matching SPDX SBOMs and
       `dependency-inventory-*.json` artifacts, and verify archive provenance
       with `gh attestation verify <archive> --repo Bare-Systems/Tardigrade`

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -52,6 +52,10 @@ Use this checklist before tagging and distributing a Tardigrade release.
       referenced release assets are visible and the install smoke passes.
       `homebrew-tap/README.md` is tap-owned; update it only when public
       support policy or install instructions change.
+- [ ] After the public tap update is pushed, run the black-box public-tap smoke
+      with `./scripts/test-public-homebrew-tap.sh --install-mode qualified` and
+      `./scripts/test-public-homebrew-tap.sh --install-mode tap-short`, or run
+      the manual `Public Homebrew Smoke` workflow.
 - [ ] Verify both Darwin archives have matching SPDX SBOMs and
       `dependency-inventory-*.json` artifacts, and verify archive provenance
       with `gh attestation verify <archive> --repo Bare-Systems/Tardigrade`

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -350,6 +350,23 @@ brew install tardigrade
 tardi version
 ```
 
+Validate the published tap itself after release publication with the black-box
+public-tap smoke:
+
+```bash
+./scripts/test-public-homebrew-tap.sh --install-mode qualified
+./scripts/test-public-homebrew-tap.sh --install-mode tap-short
+```
+
+The first mode runs `brew install bare-systems/tap/tardigrade`. The second mode
+runs the explicit tap/trust flow Homebrew currently requires for non-official
+taps before `brew install tardigrade`. Both modes run from a temporary directory
+outside the checkout, verify `tardi` and the `tardigrade` alias resolve under
+the Homebrew prefix, check the release identity, audit installed-binary linkage,
+and exercise `init static`, `check`, `run`, a static GET, `/health`, and clean
+SIGINT shutdown. `.github/workflows/public-homebrew-smoke.yml` runs this as a
+manual/scheduled post-release smoke on macOS and Linux.
+
 ## Service files
 
 Pre-built service files for host-native installs:

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -354,18 +354,21 @@ Validate the published tap itself after release publication with the black-box
 public-tap smoke:
 
 ```bash
-./scripts/test-public-homebrew-tap.sh --install-mode qualified
-./scripts/test-public-homebrew-tap.sh --install-mode tap-short
+./scripts/test-public-homebrew-tap.sh --install-mode qualified --expected-version X.Y.Z
+./scripts/test-public-homebrew-tap.sh --install-mode tap-short --expected-version X.Y.Z
 ```
 
 The first mode runs `brew install bare-systems/tap/tardigrade`. The second mode
 runs the explicit tap/trust flow Homebrew currently requires for non-official
 taps before `brew install tardigrade`. Both modes run from a temporary directory
 outside the checkout, verify `tardi` and the `tardigrade` alias resolve under
-the Homebrew prefix, check the release identity, audit installed-binary linkage,
-and exercise `init static`, `check`, `run`, a static GET, `/health`, and clean
-SIGINT shutdown. `.github/workflows/public-homebrew-smoke.yml` runs this as a
-manual/scheduled post-release smoke on macOS and Linux.
+the Homebrew prefix, check the public tap formula and installed binary against
+the expected release identity, audit installed-binary linkage, and exercise
+`init static`, `check`, `run`, a static GET, `/health`, and clean SIGINT
+shutdown. If `--expected-version` is omitted, the script resolves the latest
+stable GitHub release independently of the tap under test.
+`.github/workflows/public-homebrew-smoke.yml` runs this as a manual/scheduled
+post-release smoke on macOS and Linux.
 
 ## Service files
 

--- a/scripts/audit-dependencies.sh
+++ b/scripts/audit-dependencies.sh
@@ -159,7 +159,7 @@ resolve_build_sources() {
 is_nonproduction_file() {
     case "$1" in
     .git/* | .zig/* | .zig-cache/* | zig-out/* | tests/* | scripts/interop/* | benchmarks/* | src/*/testdata/* | scripts/remote-bench.sh | scripts/profile.sh) return 0 ;;
-    scripts/test-deb-package.sh | scripts/test-rpm-package.sh | scripts/test-homebrew-formula.sh | scripts/test-homebrew-release-formula.sh | scripts/test-homebrew-tap-sync.sh | scripts/test-install.sh | scripts/test-docker-image.sh | scripts/test-launchd-service.sh) return 0 ;;
+    scripts/test-deb-package.sh | scripts/test-rpm-package.sh | scripts/test-homebrew-formula.sh | scripts/test-homebrew-release-formula.sh | scripts/test-homebrew-tap-sync.sh | scripts/test-public-homebrew-tap.sh | scripts/test-install.sh | scripts/test-docker-image.sh | scripts/test-launchd-service.sh) return 0 ;;
     *) return 1 ;;
     esac
 }
@@ -167,20 +167,20 @@ is_nonproduction_file() {
 is_nonproduction_zig_file() {
     case "$1" in
     .git/* | .zig/* | .zig-cache/* | zig-out/* | tests/* | scripts/interop/* | benchmarks/* | src/*/testdata/*) return 0 ;;
-    scripts/test-deb-package.sh | scripts/test-rpm-package.sh | scripts/test-homebrew-formula.sh | scripts/test-homebrew-release-formula.sh | scripts/test-homebrew-tap-sync.sh | scripts/test-install.sh | scripts/test-docker-image.sh | scripts/test-launchd-service.sh) return 0 ;;
+    scripts/test-deb-package.sh | scripts/test-rpm-package.sh | scripts/test-homebrew-formula.sh | scripts/test-homebrew-release-formula.sh | scripts/test-homebrew-tap-sync.sh | scripts/test-public-homebrew-tap.sh | scripts/test-install.sh | scripts/test-docker-image.sh | scripts/test-launchd-service.sh) return 0 ;;
     *) return 1 ;;
     esac
 }
 
 is_explicit_nonproduction_helper() {
     case "$1" in
-    scripts/test-deb-package.sh | scripts/test-rpm-package.sh | scripts/test-homebrew-formula.sh | scripts/test-homebrew-release-formula.sh | scripts/test-homebrew-tap-sync.sh | scripts/test-install.sh | scripts/test-docker-image.sh | scripts/test-launchd-service.sh) return 0 ;;
+    scripts/test-deb-package.sh | scripts/test-rpm-package.sh | scripts/test-homebrew-formula.sh | scripts/test-homebrew-release-formula.sh | scripts/test-homebrew-tap-sync.sh | scripts/test-public-homebrew-tap.sh | scripts/test-install.sh | scripts/test-docker-image.sh | scripts/test-launchd-service.sh) return 0 ;;
     *) return 1 ;;
     esac
 }
 
 explicit_nonproduction_helper_pattern() {
-    printf '%s\n' 'scripts/test-deb-package\.sh|scripts/test-rpm-package\.sh|scripts/test-homebrew-formula\.sh|scripts/test-homebrew-release-formula\.sh|scripts/test-homebrew-tap-sync\.sh|scripts/test-install\.sh|scripts/test-docker-image\.sh|scripts/test-launchd-service\.sh|scripts/interop/[A-Za-z0-9_./@-]+|scripts/remote-bench\.sh|scripts/profile\.sh|benchmarks/[A-Za-z0-9_./@-]+|\./\.github/workflows/[A-Za-z0-9_.@/-]+\.ya?ml'
+    printf '%s\n' 'scripts/test-deb-package\.sh|scripts/test-rpm-package\.sh|scripts/test-homebrew-formula\.sh|scripts/test-homebrew-release-formula\.sh|scripts/test-homebrew-tap-sync\.sh|scripts/test-public-homebrew-tap\.sh|scripts/test-install\.sh|scripts/test-docker-image\.sh|scripts/test-launchd-service\.sh|scripts/interop/[A-Za-z0-9_./@-]+|scripts/remote-bench\.sh|scripts/profile\.sh|benchmarks/[A-Za-z0-9_./@-]+|\./\.github/workflows/[A-Za-z0-9_.@/-]+\.ya?ml'
 }
 
 forbidden_dependency_pattern() {

--- a/scripts/test-public-homebrew-tap.sh
+++ b/scripts/test-public-homebrew-tap.sh
@@ -14,17 +14,23 @@ SERVER_PID=""
 
 usage() {
     cat <<'EOF'
-Usage: test-public-homebrew-tap.sh [--install-mode qualified|tap-short]
+Usage: test-public-homebrew-tap.sh [--install-mode qualified|tap-short] [--expected-version VERSION]
 
 Installs Tardigrade from the public Bare-Systems/homebrew-tap path and smokes
 only the installed Homebrew artifact from a temporary directory outside the
 checkout. This is intended for post-release/manual/scheduled distribution
-validation, not PR-time generated-formula validation.
+validation, not PR-time generated-formula validation. If --expected-version
+is omitted, the latest stable GitHub release is used.
 EOF
 }
 
 # shellcheck disable=SC2317,SC2329 # invoked by trap
 cleanup() {
+    local status="$1"
+    if [ "$status" -ne 0 ] && [ -f "$TMPDIR/public-tap-runtime/server.log" ]; then
+        echo "--- public Homebrew smoke server.log ---" >&2
+        cat "$TMPDIR/public-tap-runtime/server.log" >&2
+    fi
     if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
         kill -INT "$SERVER_PID" >/dev/null 2>&1 || true
         wait "$SERVER_PID" >/dev/null 2>&1 || true
@@ -40,12 +46,18 @@ cleanup() {
     fi
     rm -rf "$TMPDIR"
 }
-trap cleanup EXIT
+trap 'status=$?; cleanup "$status"; exit "$status"' EXIT
+
+EXPECTED_VERSION="${EXPECTED_VERSION:-}"
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
     --install-mode)
         INSTALL_MODE="$2"
+        shift 2
+        ;;
+    --expected-version)
+        EXPECTED_VERSION="$2"
         shift 2
         ;;
     -h | --help)
@@ -86,16 +98,34 @@ if brew tap | grep -Fx "$TAP_NAME" >/dev/null; then
     exit 2
 fi
 
+strip_tag_prefix() {
+    printf '%s\n' "${1#v}"
+}
+
+latest_stable_release_version() {
+    local tag
+    if command -v gh >/dev/null 2>&1; then
+        tag="$(gh release view --repo Bare-Systems/Tardigrade --json tagName -q .tagName)"
+    else
+        tag="$(
+            curl -fsSL https://api.github.com/repos/Bare-Systems/Tardigrade/releases/latest |
+                ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("tag_name")'
+        )"
+    fi
+    strip_tag_prefix "$tag"
+}
+
+formula_stable_version() {
+    brew info --json=v2 "$FORMULA_REF" |
+        ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("formulae").fetch(0).fetch("versions").fetch("stable")'
+}
+
 emit_evidence() {
-    local installed="$1" alias_path="$2" version_output="$3" audit_output="$4"
-    local tap_repo tap_commit formula_version install_ref
+    local installed="$1" alias_path="$2" version_output="$3" audit_output="$4" formula_version="$5"
+    local tap_repo tap_commit install_ref
 
     tap_repo="$(brew --repo "$TAP_NAME")"
     tap_commit="$(git -C "$tap_repo" rev-parse HEAD)"
-    formula_version="$(
-        brew info --json=v2 "$FORMULA_REF" |
-            ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("formulae").fetch(0).fetch("versions").fetch("stable")'
-    )"
     if [ "$INSTALL_MODE" = qualified ]; then
         install_ref="$FORMULA_REF"
     else
@@ -109,6 +139,7 @@ emit_evidence() {
     printf 'os_arch=%s %s\n' "$(uname -s)" "$(uname -m)"
     printf 'tap=%s\n' "$TAP_NAME"
     printf 'tap_commit=%s\n' "$tap_commit"
+    printf 'expected_version=%s\n' "$EXPECTED_VERSION"
     printf 'formula_version=%s\n' "$formula_version"
     printf 'installed_binary=%s\n' "$installed"
     printf 'installed_alias=%s\n' "$alias_path"
@@ -133,6 +164,22 @@ tap-short)
 esac
 
 brew test "$FORMULA_REF" --verbose
+
+if [ -z "$EXPECTED_VERSION" ]; then
+    EXPECTED_VERSION="$(latest_stable_release_version)"
+else
+    EXPECTED_VERSION="$(strip_tag_prefix "$EXPECTED_VERSION")"
+fi
+if [ -z "$EXPECTED_VERSION" ]; then
+    echo "expected release version could not be resolved" >&2
+    exit 2
+fi
+
+formula_version="$(formula_stable_version)"
+if [ "$formula_version" != "$EXPECTED_VERSION" ]; then
+    echo "public tap is stale: expected formula version $EXPECTED_VERSION, got $formula_version" >&2
+    exit 1
+fi
 
 prefix="$(brew --prefix)"
 installed="$(command -v tardi)"
@@ -159,6 +206,13 @@ ruby -e 'exit(File.realpath(ARGV.fetch(0)) == File.realpath(ARGV.fetch(1)) ? 0 :
 }
 
 version_output="$("$installed" version)"
+case "$version_output" in
+"$EXPECTED_VERSION "*) ;;
+*)
+    echo "installed binary version does not match $EXPECTED_VERSION: $version_output" >&2
+    exit 1
+    ;;
+esac
 printf '%s\n' "$version_output" | grep -F 'tls-profile=general' >/dev/null
 printf '%s\n' "$version_output" | grep -F 'tls-backend=native' >/dev/null
 
@@ -196,7 +250,6 @@ for _ in $(seq 1 50); do
 done
 
 if [ "$ready" != true ]; then
-    cat server.log >&2
     echo "public Homebrew artifact did not become ready" >&2
     exit 1
 fi
@@ -207,5 +260,5 @@ kill -INT "$SERVER_PID"
 wait "$SERVER_PID"
 SERVER_PID=""
 
-emit_evidence "$installed" "$alias_path" "$version_output" "$audit_status"
+emit_evidence "$installed" "$alias_path" "$version_output" "$audit_status" "$formula_version"
 printf 'Public Homebrew tap smoke passed\n'

--- a/scripts/test-public-homebrew-tap.sh
+++ b/scripts/test-public-homebrew-tap.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TAP_NAME="bare-systems/tap"
+FORMULA_REF="$TAP_NAME/tardigrade"
+INSTALL_MODE="qualified"
+TMPDIR="$(mktemp -d)"
+INSTALLED_FORMULA=false
+TAPPED=false
+TRUSTED_FORMULA=false
+SERVER_PID=""
+
+usage() {
+    cat <<'EOF'
+Usage: test-public-homebrew-tap.sh [--install-mode qualified|tap-short]
+
+Installs Tardigrade from the public Bare-Systems/homebrew-tap path and smokes
+only the installed Homebrew artifact from a temporary directory outside the
+checkout. This is intended for post-release/manual/scheduled distribution
+validation, not PR-time generated-formula validation.
+EOF
+}
+
+# shellcheck disable=SC2317,SC2329 # invoked by trap
+cleanup() {
+    if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+        kill -INT "$SERVER_PID" >/dev/null 2>&1 || true
+        wait "$SERVER_PID" >/dev/null 2>&1 || true
+    fi
+    if [ "$INSTALLED_FORMULA" = true ]; then
+        brew uninstall --formula tardigrade >/dev/null 2>&1 || true
+    fi
+    if [ "$TRUSTED_FORMULA" = true ]; then
+        brew untrust --formula "$FORMULA_REF" >/dev/null 2>&1 || true
+    fi
+    if [ "$TAPPED" = true ]; then
+        brew untap "$TAP_NAME" >/dev/null 2>&1 || true
+    fi
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --install-mode)
+        INSTALL_MODE="$2"
+        shift 2
+        ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "unknown argument: $1" >&2
+        usage >&2
+        exit 2
+        ;;
+    esac
+done
+
+case "$INSTALL_MODE" in
+qualified | tap-short) ;;
+*)
+    echo "invalid install mode: $INSTALL_MODE (expected qualified or tap-short)" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if ! command -v brew >/dev/null 2>&1; then
+    echo "Homebrew is required for public tap smoke testing" >&2
+    exit 2
+fi
+if ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required for public tap smoke testing" >&2
+    exit 2
+fi
+if brew list --formula tardigrade >/dev/null 2>&1; then
+    echo "refusing to run smoke while a Homebrew tardigrade formula is already installed" >&2
+    exit 2
+fi
+if brew tap | grep -Fx "$TAP_NAME" >/dev/null; then
+    echo "refusing to run smoke while public tap is already tapped: $TAP_NAME" >&2
+    exit 2
+fi
+
+emit_evidence() {
+    local installed="$1" alias_path="$2" version_output="$3" audit_output="$4"
+    local tap_repo tap_commit formula_version install_ref
+
+    tap_repo="$(brew --repo "$TAP_NAME")"
+    tap_commit="$(git -C "$tap_repo" rev-parse HEAD)"
+    formula_version="$(
+        brew info --json=v2 "$FORMULA_REF" |
+            ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("formulae").fetch(0).fetch("versions").fetch("stable")'
+    )"
+    if [ "$INSTALL_MODE" = qualified ]; then
+        install_ref="$FORMULA_REF"
+    else
+        install_ref="tardigrade"
+    fi
+
+    printf 'Public Homebrew smoke evidence\n'
+    printf 'install_mode=%s\n' "$INSTALL_MODE"
+    printf 'install_ref=%s\n' "$install_ref"
+    printf 'homebrew_version<<EOF\n%s\nEOF\n' "$(brew --version)"
+    printf 'os_arch=%s %s\n' "$(uname -s)" "$(uname -m)"
+    printf 'tap=%s\n' "$TAP_NAME"
+    printf 'tap_commit=%s\n' "$tap_commit"
+    printf 'formula_version=%s\n' "$formula_version"
+    printf 'installed_binary=%s\n' "$installed"
+    printf 'installed_alias=%s\n' "$alias_path"
+    printf 'tardi_version<<EOF\n%s\nEOF\n' "$version_output"
+    printf 'linkage_audit=%s\n' "$audit_output"
+}
+
+case "$INSTALL_MODE" in
+qualified)
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install --formula "$FORMULA_REF" --verbose
+    INSTALLED_FORMULA=true
+    TAPPED=true
+    ;;
+tap-short)
+    HOMEBREW_NO_AUTO_UPDATE=1 brew tap "$TAP_NAME" >/dev/null
+    TAPPED=true
+    HOMEBREW_NO_AUTO_UPDATE=1 brew trust --formula "$FORMULA_REF" >/dev/null
+    TRUSTED_FORMULA=true
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install --formula tardigrade --verbose
+    INSTALLED_FORMULA=true
+    ;;
+esac
+
+brew test "$FORMULA_REF" --verbose
+
+prefix="$(brew --prefix)"
+installed="$(command -v tardi)"
+alias_path="$(command -v tardigrade)"
+case "$installed" in
+"$prefix"/*) ;;
+*)
+    echo "tardi resolved outside Homebrew prefix: $installed (prefix: $prefix)" >&2
+    exit 1
+    ;;
+esac
+case "$alias_path" in
+"$prefix"/*) ;;
+*)
+    echo "tardigrade alias resolved outside Homebrew prefix: $alias_path (prefix: $prefix)" >&2
+    exit 1
+    ;;
+esac
+test -x "$installed"
+test -e "$alias_path"
+ruby -e 'exit(File.realpath(ARGV.fetch(0)) == File.realpath(ARGV.fetch(1)) ? 0 : 1)' "$installed" "$alias_path" || {
+    echo "tardigrade does not resolve to the installed tardi binary" >&2
+    exit 1
+}
+
+version_output="$("$installed" version)"
+printf '%s\n' "$version_output" | grep -F 'tls-profile=general' >/dev/null
+printf '%s\n' "$version_output" | grep -F 'tls-backend=native' >/dev/null
+
+"$REPO_ROOT/scripts/audit-release-binary.sh" \
+    --binary "$installed" \
+    --profile general \
+    --output "$TMPDIR/dependency-inventory.json" >/dev/null
+audit_status="$(
+    ruby -rjson -e 'puts JSON.parse(File.read(ARGV.fetch(0))).fetch("status")' \
+        "$TMPDIR/dependency-inventory.json"
+)"
+test "$audit_status" = pass
+
+smoke_dir="$TMPDIR/public-tap-runtime"
+mkdir -p "$smoke_dir/public"
+printf '%s\n' '<h1>public-tap-smoke</h1>' > "$smoke_dir/public/index.html"
+
+cd "$smoke_dir"
+"$installed" init static > tardigrade.conf
+"$installed" check tardigrade.conf
+"$installed" run -c tardigrade.conf > server.log 2>&1 &
+SERVER_PID="$!"
+
+body=""
+ready=false
+for _ in $(seq 1 50); do
+    if body="$(curl -fsS -H 'Host: localhost' http://127.0.0.1:8080/ 2>/dev/null)"; then
+        ready=true
+        break
+    fi
+    if ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.2
+done
+
+if [ "$ready" != true ]; then
+    cat server.log >&2
+    echo "public Homebrew artifact did not become ready" >&2
+    exit 1
+fi
+
+test "$body" = '<h1>public-tap-smoke</h1>'
+test "$(curl -fsS -H 'Host: localhost' http://127.0.0.1:8080/health)" = ok
+kill -INT "$SERVER_PID"
+wait "$SERVER_PID"
+SERVER_PID=""
+
+emit_evidence "$installed" "$alias_path" "$version_output" "$audit_status"
+printf 'Public Homebrew tap smoke passed\n'

--- a/scripts/test-public-homebrew-tap.sh
+++ b/scripts/test-public-homebrew-tap.sh
@@ -104,8 +104,9 @@ strip_tag_prefix() {
 
 latest_stable_release_version() {
     local tag
-    if command -v gh >/dev/null 2>&1; then
-        tag="$(gh release view --repo Bare-Systems/Tardigrade --json tagName -q .tagName)"
+    if command -v gh >/dev/null 2>&1 &&
+        tag="$(gh release view --repo Bare-Systems/Tardigrade --json tagName -q .tagName 2>/dev/null)"; then
+        :
     else
         tag="$(
             curl -fsSL https://api.github.com/repos/Bare-Systems/Tardigrade/releases/latest |


### PR DESCRIPTION
## Summary
- add a black-box `scripts/test-public-homebrew-tap.sh` that installs from `bare-systems/tap`, verifies `tardi` and `tardigrade` resolve under the Homebrew prefix, checks release identity and native TLS reporting, audits the installed binary, and runs init/check/run/static/health/SIGINT from a temp directory
- add a manual/scheduled `Public Homebrew Smoke` workflow covering macOS ARM64, macOS x86_64, Linux x86_64, and Linux ARM64 for both fully qualified and explicit tap/short-name install modes
- document the post-release public tap smoke in packaging docs and the release checklist

Refs #670. The issue should be closed after this PR merges and the scheduled/manual smoke has run successfully on the hosted platform matrix.

## Validation
- `bash -n scripts/test-public-homebrew-tap.sh scripts/audit-dependencies.sh`
- `shellcheck scripts/test-public-homebrew-tap.sh scripts/audit-dependencies.sh`
- `git diff --check`
- `./scripts/audit-dependencies.sh`
- `./scripts/test-public-homebrew-tap.sh --install-mode qualified` on local Darwin arm64: passed against public tap commit `b7bda62bda3da9127e52cedd06bb9ffed51aa635`, formula `0.6.2`, Homebrew `6.0.18-173-g14dedc3`
- `./scripts/test-public-homebrew-tap.sh --install-mode tap-short` on local Darwin arm64: passed against the same public tap commit/formula

Note: `actionlint` is not installed in this local environment, so workflow syntax validation is left to GitHub CI.