### PR TITLE
docs: close F-05 live TLS surface evidence

### DIFF
--- a/docs/F05_LIVE_TLS_SURFACE_672.md
+++ b/docs/F05_LIVE_TLS_SURFACE_672.md
@@ -1,0 +1,110 @@
+# F-05 Live Native TLS Surface Evidence (#672)
+
+Date: 2026-08-26
+
+This note records the sanitized evidence for the F-05 live TLS surface pass.
+The target was an isolated loopback-only `tardi` listener with synthetic
+credentials. Private keys, ticket keys, TLS keylog material, and reusable
+session secrets were not committed.
+
+## Target
+
+- Target: `127.0.0.1:18443`
+- Binary: `./zig-out/bin/tardi`
+- `tardi version`: `dev (tls-profile=general, tls-backend=native)`
+- Source SHA: `d2bc042db94f45850c4a9defdb4ebc821768107f`
+- OS/architecture: Darwin 25.3.0, arm64
+- OpenSSL: OpenSSL 3.6.3, 2026-06-09
+- Scanner tooling:
+  - Nmap 7.98 with `ssl-enum-ciphers`
+  - `testssl.sh` 3.3dev cloned into `/tmp`
+- Listener protocol policy: TLS 1.3 over record transport, ALPN `h2` and
+  `http/1.1`; the live record listener policy offers
+  `TLS_AES_128_GCM_SHA256` and X25519 by default.
+
+## Synthetic Identities
+
+All identities were generated under `/tmp` and removed from the repository
+surface. Only public metadata is retained here.
+
+| Name | Key / signature exercised | SAN | SHA-256 fingerprint |
+| --- | --- | --- | --- |
+| `tardigrade.test` | Ed25519 | `tardigrade.test`, `default.tardigrade.test` | `CF:CF:54:B1:3F:77:AA:C7:27:08:F6:3C:22:2E:15:09:E1:95:08:9C:CA:30:2E:47:63:E2:40:E1:E6:34:10:FA` |
+| `ecdsa.tardigrade.test` | ECDSA P-256/SHA-256 | `ecdsa.tardigrade.test` | `C2:A8:5D:75:E9:5D:06:FB:71:86:D2:54:08:77:9C:24:A2:C6:21:80:26:9C:17:9F:CE:5A:B2:36:A0:98:E8:8E` |
+| `rsa.tardigrade.test` | RSA-2048 candidate | `rsa.tardigrade.test` | `CB:09:F4:6C:7B:27:BD:C7:3A:0E:96:75:3D:C7:3E:54:10:0E:4D:A6:B6:52:5C:F9:27:C0:B0:59:07:4F:79:ED` |
+
+The RSA credential was configured only to verify fail-closed behavior for the
+current live record policy. RSA-PSS is an engine-level capability, but the
+default live record listener policy does not advertise RSA-PSS signatures.
+
+## Scanner Pass
+
+`tls-scan` / `tls_scan` was not available on the host. Two maintained
+black-box scanners were run as equivalents and their full text/XML/JSON output
+was retained in the local run artifact directory during the engagement.
+
+```bash
+nmap -Pn -sV --version-all --script +ssl-enum-ciphers \
+  --script-args tls.servername=tardigrade.test \
+  -p 18443 -oX tls-nmap.xml 127.0.0.1
+```
+
+Result: the port was open, but Nmap did not enumerate ciphers. The listener
+requires an acceptable ALPN offer; Nmap's cipher script does not provide one
+for this target shape.
+
+```bash
+testssl.sh --protocols --server-preference --cipher-per-proto \
+  --jsonfile-pretty testssl.json --logfile testssl.log \
+  --warnings batch 127.0.0.1:18443
+```
+
+Result: `testssl.sh` reported SSLv2/SSLv3/TLS 1.0/TLS 1.1/TLS 1.2 as not
+offered. It also reported TLS 1.3 as not offered because its protocol/cipher
+probes do not send the ALPN extension required by this listener. Manual
+ALPN-bearing OpenSSL and `nghttp` probes below are therefore the authoritative
+semantic evidence for TLS 1.3, cipher, SNI, and ALPN behavior.
+
+## Manual Probe Matrix
+
+All OpenSSL probes used `/opt/homebrew/bin/openssl` 3.6.3 against the loopback
+listener.
+
+| Matrix row | Probe | Observed result |
+| --- | --- | --- |
+| TLS 1.3 / X25519 / baseline cipher success | `openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn h2,http/1.1 -ciphersuites TLS_AES_128_GCM_SHA256 -groups X25519 -brief` | Success: `Protocol version: TLSv1.3`, `Ciphersuite: TLS_AES_128_GCM_SHA256`, `Signature type: ed25519`, `Peer Temp Key: X25519` |
+| TLS 1.2 rejected | `openssl s_client -connect 127.0.0.1:18443 -tls1_2 -servername tardigrade.test -alpn http/1.1 -brief` | Failed closed with alert `protocol version` |
+| Cipher no-overlap | `openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn http/1.1 -ciphersuites TLS_AES_128_CCM_SHA256 -brief` | Failed closed with alert `handshake failure` |
+| AES-256 pinned | `openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn http/1.1 -ciphersuites TLS_AES_256_GCM_SHA384 -brief` | Failed with `handshake failure`; not product-enabled by the live record listener policy |
+| ChaCha20 pinned | `openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn http/1.1 -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -brief` | Failed with `handshake failure`; not product-enabled by the live record listener policy |
+| P-256 group pinned | `openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn http/1.1 -groups P-256 -brief` | Failed with `handshake failure`; not product-enabled by the live record listener policy |
+| Group no-overlap | `openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn http/1.1 -groups P-384 -brief` | Failed closed with alert `handshake failure` |
+| Ed25519 signature pin | `openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn http/1.1 -sigalgs ed25519 -brief` | Success; selected `CN=tardigrade.test`, signature type `ed25519` |
+| ECDSA P-256 signature pin | `openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername ecdsa.tardigrade.test -alpn http/1.1 -sigalgs ecdsa_secp256r1_sha256 -brief` | Success; selected `CN=ecdsa.tardigrade.test`, signature type `ecdsa_secp256r1_sha256` |
+| RSA-PSS signature pin | `openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername rsa.tardigrade.test -alpn http/1.1 -sigalgs rsa_pss_rsae_sha256 -brief` | Failed closed; RSA-PSS is not advertised by the default live record listener policy |
+| No applicable credential | `openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername ecdsa.tardigrade.test -alpn http/1.1 -sigalgs rsa_pss_rsae_sha256 -brief` | Failed closed with alert `handshake failure` |
+| Missing SNI | `openssl s_client -connect 127.0.0.1:18443 -tls1_3 -noservername -alpn http/1.1 -brief` | Success; selected the default `CN=tardigrade.test` identity, matching the documented general-profile absent-SNI policy |
+| Unknown SNI | `openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername unknown.tardigrade.test -alpn http/1.1 -brief` | Failed closed with alert `handshake failure`; the default certificate SAN did not cover the requested name |
+| ALPN no-overlap | `openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn acme-tls/1 -brief` | Failed closed with alert `no application protocol` |
+| HTTP/1.1 ALPN request | `printf 'GET /health HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n' \| openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn http/1.1 -quiet` | Returned `HTTP/1.1 200 OK` and body `ok` |
+| HTTP/2 ALPN request | `nghttp -v -y -t 5 -H ':authority: tardigrade.test' https://127.0.0.1:18443/health` | Negotiated `h2`, exchanged SETTINGS, received `:status: 200` and body `ok` |
+| Clean TLS close | `openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn http/1.1 -brief </dev/null` | Success with `DONE` |
+| Abrupt truncation | Python TLS client completed TLS 1.3, sent a partial HTTP/1.1 request, then closed with TCP RST via `SO_LINGER` | Listener logged `error.SocketReadFailed` for the edge connection and remained healthy |
+| Repeated malformed handshakes | 30 malformed TLS records sent with `nc` | Listener logged bounded `error.TruncatedStream` handshake failures and did not crash or wedge |
+| Post-failure health | Same HTTP/1.1 ALPN request after the malformed-handshake burst | Returned `HTTP/1.1 200 OK` and body `ok` |
+
+## Outcome
+
+- No unintended legacy protocol exposure was observed.
+- The live listener accepted only the product-enabled baseline cipher/group
+  tuple for record TLS and failed closed for non-overlap probes.
+- SNI behavior matched `docs/TLS_DEPENDENCY_POLICY.md`: explicit matching SNI
+  selected the configured identity, absent SNI selected the default identity,
+  and unknown SNI outside the default certificate SAN failed closed.
+- ALPN `http/1.1` and `h2` both reached their application entrypoints.
+- ALPN no-overlap failed with `no_application_protocol`.
+- Clean close and abrupt truncation were distinguishable in live behavior.
+- A bounded malformed-handshake run did not crash or wedge the listener.
+
+No product defect was found in this pass, so no lower-layer regression test was
+added.

--- a/docs/F05_LIVE_TLS_SURFACE_672.md
+++ b/docs/F05_LIVE_TLS_SURFACE_672.md
@@ -40,9 +40,32 @@ default live record listener policy does not advertise RSA-PSS signatures.
 
 ## Scanner Pass
 
-`tls-scan` / `tls_scan` was not available on the host. Two maintained
-black-box scanners were run as equivalents and their full text/XML/JSON output
-is retained under [`docs/evidence/f05-672/`](evidence/f05-672/).
+`tls-scan` / `tls_scan` was not available on the host. The successful
+scanner-equivalent pass is a committed wrapper around maintained OpenSSL
+3.6.3. It preserves scanner enumeration semantics by enumerating OpenSSL's
+local TLS 1.3 ciphersuite list and probing each candidate independently
+against the live listener while always sending the listener's mandatory ALPN.
+It also probes legacy protocol versions. Full retained outputs:
+[`openssl-alpn-cipher-enum.sh`](evidence/f05-672/openssl-alpn-cipher-enum.sh)
+and
+[`openssl-alpn-cipher-enum.txt`](evidence/f05-672/openssl-alpn-cipher-enum.txt).
+
+```bash
+OPENSSL_BIN=/opt/homebrew/bin/openssl \
+  sh docs/evidence/f05-672/openssl-alpn-cipher-enum.sh \
+  > docs/evidence/f05-672/openssl-alpn-cipher-enum.txt 2>&1
+```
+
+Result: OpenSSL enumerated the TLS 1.3 candidates
+`TLS_AES_256_GCM_SHA384`, `TLS_CHACHA20_POLY1305_SHA256`, and
+`TLS_AES_128_GCM_SHA256`. With SNI `tardigrade.test` and ALPN `http/1.1`,
+only `TLS_AES_128_GCM_SHA256` negotiated successfully. AES-256 and ChaCha20
+failed closed with alert `handshake failure`, and TLS 1.2 failed closed with
+alert `protocol version`. TLS 1.1 and TLS 1.0 did not negotiate.
+
+The following additional maintained scanners were attempted and are retained
+as supplemental evidence. They confirm that generic scanners without an ALPN
+override cannot enumerate this target shape.
 
 ```bash
 nmap -Pn -sV --version-all --script +ssl-enum-ciphers \
@@ -64,9 +87,7 @@ testssl.sh --protocols --server-preference --cipher-per-proto \
 
 Result: `testssl.sh` reported SSLv2/SSLv3/TLS 1.0/TLS 1.1/TLS 1.2 as not
 offered. It also reported TLS 1.3 as not offered because its protocol/cipher
-probes do not send the ALPN extension required by this listener. Manual
-ALPN-bearing OpenSSL and `nghttp` probes below are therefore the authoritative
-semantic evidence for TLS 1.3, cipher, SNI, and ALPN behavior. Full retained
+probes do not send the ALPN extension required by this listener. Full retained
 outputs: [`testssl.log`](evidence/f05-672/testssl.log) and
 [`testssl.json`](evidence/f05-672/testssl.json). The retained `testssl.sh`
 banner includes its own short display version; the full commit above was

--- a/docs/F05_LIVE_TLS_SURFACE_672.md
+++ b/docs/F05_LIVE_TLS_SURFACE_672.md
@@ -17,7 +17,8 @@ session secrets were not committed.
 - OpenSSL: OpenSSL 3.6.3, 2026-06-09
 - Scanner tooling:
   - Nmap 7.98 with `ssl-enum-ciphers`
-  - `testssl.sh` 3.3dev cloned into `/tmp`
+  - `testssl.sh` 3.3dev cloned into `/tmp`, commit
+    `6d555cac4e151c61e9836559bcbd437b3f0a75c3`
 - Listener protocol policy: TLS 1.3 over record transport, ALPN `h2` and
   `http/1.1`; the live record listener policy offers
   `TLS_AES_128_GCM_SHA256` and X25519 by default.
@@ -41,7 +42,7 @@ default live record listener policy does not advertise RSA-PSS signatures.
 
 `tls-scan` / `tls_scan` was not available on the host. Two maintained
 black-box scanners were run as equivalents and their full text/XML/JSON output
-was retained in the local run artifact directory during the engagement.
+is retained under [`docs/evidence/f05-672/`](evidence/f05-672/).
 
 ```bash
 nmap -Pn -sV --version-all --script +ssl-enum-ciphers \
@@ -51,7 +52,9 @@ nmap -Pn -sV --version-all --script +ssl-enum-ciphers \
 
 Result: the port was open, but Nmap did not enumerate ciphers. The listener
 requires an acceptable ALPN offer; Nmap's cipher script does not provide one
-for this target shape.
+for this target shape. Full retained outputs:
+[`tls-nmap.txt`](evidence/f05-672/tls-nmap.txt) and
+[`tls-nmap.xml`](evidence/f05-672/tls-nmap.xml).
 
 ```bash
 testssl.sh --protocols --server-preference --cipher-per-proto \
@@ -63,7 +66,34 @@ Result: `testssl.sh` reported SSLv2/SSLv3/TLS 1.0/TLS 1.1/TLS 1.2 as not
 offered. It also reported TLS 1.3 as not offered because its protocol/cipher
 probes do not send the ALPN extension required by this listener. Manual
 ALPN-bearing OpenSSL and `nghttp` probes below are therefore the authoritative
-semantic evidence for TLS 1.3, cipher, SNI, and ALPN behavior.
+semantic evidence for TLS 1.3, cipher, SNI, and ALPN behavior. Full retained
+outputs: [`testssl.log`](evidence/f05-672/testssl.log) and
+[`testssl.json`](evidence/f05-672/testssl.json). The retained `testssl.sh`
+banner includes its own short display version; the full commit above was
+verified from the cloned scanner repository with `git rev-parse HEAD`.
+
+## Live Certificate Surface
+
+Each row was captured from the live listener with:
+
+```bash
+openssl s_client \
+  -connect 127.0.0.1:18443 \
+  -tls1_3 \
+  -servername <name> \
+  -alpn http/1.1 \
+  -showcerts </dev/null
+
+openssl s_client ... -showcerts </dev/null 2>/dev/null |
+  openssl x509 -noout -subject -issuer -dates \
+    -ext subjectAltName -fingerprint -sha256 -text
+```
+
+| Name | Live result | Retained output |
+| --- | --- | --- |
+| `tardigrade.test` | Presented a one-certificate self-signed chain with `subject=CN=tardigrade.test`, `issuer=CN=tardigrade.test`, SAN `DNS:tardigrade.test, DNS:default.tardigrade.test`, validity `Aug 26 14:03:43 2026 GMT` to `Sep 2 14:03:43 2026 GMT`, SHA-256 fingerprint `CF:CF:54:B1:3F:77:AA:C7:27:08:F6:3C:22:2E:15:09:E1:95:08:9C:CA:30:2E:47:63:E2:40:E1:E6:34:10:FA`, public-key algorithm `ED25519`, and signature algorithm `ED25519`. | [`live-cert-tardigrade.test.txt`](evidence/f05-672/live-cert-tardigrade.test.txt) |
+| `ecdsa.tardigrade.test` | Presented a one-certificate self-signed chain with `subject=CN=ecdsa.tardigrade.test`, `issuer=CN=ecdsa.tardigrade.test`, SAN `DNS:ecdsa.tardigrade.test`, validity `Aug 26 14:03:43 2026 GMT` to `Sep 2 14:03:43 2026 GMT`, SHA-256 fingerprint `C2:A8:5D:75:E9:5D:06:FB:71:86:D2:54:08:77:9C:24:A2:C6:21:80:26:9C:17:9F:CE:5A:B2:36:A0:98:E8:8E`, public-key algorithm `id-ecPublicKey` / P-256, and signature algorithm `ecdsa-with-SHA256`. | [`live-cert-ecdsa.tardigrade.test.txt`](evidence/f05-672/live-cert-ecdsa.tardigrade.test.txt) |
+| `rsa.tardigrade.test` | No live certificate was presented. The handshake failed before certificate transmission with TLS alert `internal error`, matching the default live record listener policy that does not advertise RSA-PSS credentials. The synthetic public certificate metadata is retained in the identity table above for the configured candidate. | [`live-cert-rsa.tardigrade.test.txt`](evidence/f05-672/live-cert-rsa.tardigrade.test.txt) |
 
 ## Manual Probe Matrix
 
@@ -89,8 +119,8 @@ listener.
 | HTTP/1.1 ALPN request | `printf 'GET /health HTTP/1.1\r\nHost: tardigrade.test\r\nConnection: close\r\n\r\n' \| openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn http/1.1 -quiet` | Returned `HTTP/1.1 200 OK` and body `ok` |
 | HTTP/2 ALPN request | `nghttp -v -y -t 5 -H ':authority: tardigrade.test' https://127.0.0.1:18443/health` | Negotiated `h2`, exchanged SETTINGS, received `:status: 200` and body `ok` |
 | Clean TLS close | `openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn http/1.1 -brief </dev/null` | Success with `DONE` |
-| Abrupt truncation | Python TLS client completed TLS 1.3, sent a partial HTTP/1.1 request, then closed with TCP RST via `SO_LINGER` | Listener logged `error.SocketReadFailed` for the edge connection and remained healthy |
-| Repeated malformed handshakes | 30 malformed TLS records sent with `nc` | Listener logged bounded `error.TruncatedStream` handshake failures and did not crash or wedge |
+| Abrupt truncation | `python3 docs/evidence/f05-672/abrupt-truncation.py` | Client completed TLS 1.3, sent a partial HTTP/1.1 request, then closed with TCP RST via `SO_LINGER`; listener logged `error.SocketReadFailed` for the edge connection and remained healthy |
+| Repeated malformed handshakes | `for _ in $(seq 1 30); do printf '\x16\x03\x01\x00\x01\x00' \| nc 127.0.0.1 18443 >/dev/null 2>&1 \|\| true; done` | Listener logged bounded `error.TruncatedStream` handshake failures and did not crash or wedge |
 | Post-failure health | Same HTTP/1.1 ALPN request after the malformed-handshake burst | Returned `HTTP/1.1 200 OK` and body `ok` |
 
 ## Outcome

--- a/docs/SECURITY_TEST_PLAN.md
+++ b/docs/SECURITY_TEST_PLAN.md
@@ -118,6 +118,13 @@ IDs against the `tg-<decimal>-<lowercase-hex>` format. Arbitrary client values
 are discarded and a fresh ID is generated. Covered by unit tests in
 `correlation_id.zig`.
 
+**F-05 — Live native TLS surface pass** ✅ RESOLVED
+Issue #672 completed a live black-box pass against an isolated native
+`tardi` listener using synthetic credentials, OpenSSL probes, `nghttp`, and
+scanner tooling. The committed sanitized evidence, command matrix, public
+certificate metadata, and scanner-tool limitations are recorded in
+[`docs/F05_LIVE_TLS_SURFACE_672.md`](F05_LIVE_TLS_SURFACE_672.md).
+
 **F-07 — Static file serving via catch-all `location /` non-functional** ✅ RESOLVED
 A `location` block with `root` but no `index` or `try_files` directive used
 to 404 on directory requests because static serving had no default index
@@ -128,10 +135,6 @@ test in `src/http/config_file.zig` and an integration test in
 `tests/integration.zig`.
 
 ### Open Gaps
-
-**F-05 — TLS surface pass still pending**
-A dedicated TLS engagement against a Tardigrade instance with real TLS has not
-yet been completed with `tls_scan`. Run against an isolated lab target.
 
 **F-06 — Auth enforcement pass still pending**
 Bearer auth bypass, malformed bearer, token replay, and method-change bypass

--- a/docs/evidence/f05-672/abrupt-truncation.py
+++ b/docs/evidence/f05-672/abrupt-truncation.py
@@ -1,0 +1,24 @@
+import socket
+import ssl
+import struct
+
+
+HOST = "127.0.0.1"
+PORT = 18443
+SERVER_NAME = "tardigrade.test"
+
+
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+ctx.minimum_version = ssl.TLSVersion.TLSv1_3
+ctx.maximum_version = ssl.TLSVersion.TLSv1_3
+ctx.set_alpn_protocols(["http/1.1"])
+
+raw = socket.create_connection((HOST, PORT), timeout=5)
+ssock = ctx.wrap_socket(raw, server_hostname=SERVER_NAME)
+print("negotiated", ssock.version(), ssock.cipher(), ssock.selected_alpn_protocol())
+ssock.sendall(b"GET /health HTTP/1.1\r\nHost: tardigrade.test\r\n")
+ssock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+ssock.close()
+print("closed with TCP RST after partial request")

--- a/docs/evidence/f05-672/live-cert-ecdsa.tardigrade.test.txt
+++ b/docs/evidence/f05-672/live-cert-ecdsa.tardigrade.test.txt
@@ -1,0 +1,66 @@
+$ openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername ecdsa.tardigrade.test -alpn http/1.1 -showcerts </dev/null
+Connecting to 127.0.0.1
+depth=0 CN=ecdsa.tardigrade.test
+verify error:num=18:self-signed certificate
+verify return:1
+depth=0 CN=ecdsa.tardigrade.test
+verify return:1
+CONNECTED(00000003)
+---
+Certificate chain
+ 0 s:CN=ecdsa.tardigrade.test
+   i:CN=ecdsa.tardigrade.test
+   a:PKEY: EC, (prime256v1); sigalg: ecdsa-with-SHA256
+   v:NotBefore: Aug 26 14:03:43 2026 GMT; NotAfter: Sep  2 14:03:43 2026 GMT
+-----BEGIN CERTIFICATE-----
+MIIBqDCCAU2gAwIBAgIUeXf6BHoFiBRE6Vfznklw1ETQkjYwCgYIKoZIzj0EAwIw
+IDEeMBwGA1UEAwwVZWNkc2EudGFyZGlncmFkZS50ZXN0MB4XDTI2MDgyNjE0MDM0
+M1oXDTI2MDkwMjE0MDM0M1owIDEeMBwGA1UEAwwVZWNkc2EudGFyZGlncmFkZS50
+ZXN0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZdaLkmfcBnxu50snZrqaD0m4
+7lfdH1zgn74PHq+2dFZzwr2IwBaxGhYlDwZU5EIj7QsNikQwhlXMg7A4LkY4EaNl
+MGMwIAYDVR0RBBkwF4IVZWNkc2EudGFyZGlncmFkZS50ZXN0MAsGA1UdDwQEAwIH
+gDATBgNVHSUEDDAKBggrBgEFBQcDATAdBgNVHQ4EFgQU+0EbtcLTHhQURVGDq6Fh
+sigAXgQwCgYIKoZIzj0EAwIDSQAwRgIhAMO4GB+z9KtCh8q1axQExukwcKlknG7n
++i7dW/TMWnZ9AiEAl4yoOVPHnfsGowQYZahd4mlqR0N0nIeDBv6/ZWV6K2k=
+-----END CERTIFICATE-----
+---
+Server certificate
+subject=CN=ecdsa.tardigrade.test
+issuer=CN=ecdsa.tardigrade.test
+---
+No client certificate CA names sent
+Peer signing digest: SHA256
+Peer signature type: ecdsa_secp256r1_sha256
+Peer Temp Key: X25519, 253 bits
+---
+SSL handshake has read 748 bytes and written 1558 bytes
+Verification error: self-signed certificate
+---
+New, TLSv1.3, Cipher is TLS_AES_128_GCM_SHA256
+Protocol: TLSv1.3
+Server public key is 256 bit
+This TLS version forbids renegotiation.
+Compression: NONE
+Expansion: NONE
+ALPN protocol: http/1.1
+Early data was not sent
+Verify return code: 18 (self-signed certificate)
+---
+DONE
+
+$ openssl s_client ... | openssl x509 -noout -subject -issuer -dates -ext subjectAltName -fingerprint -sha256 -text
+subject=CN=ecdsa.tardigrade.test
+issuer=CN=ecdsa.tardigrade.test
+notBefore=Aug 26 14:03:43 2026 GMT
+notAfter=Sep  2 14:03:43 2026 GMT
+X509v3 Subject Alternative Name: 
+    DNS:ecdsa.tardigrade.test
+sha256 Fingerprint=C2:A8:5D:75:E9:5D:06:FB:71:86:D2:54:08:77:9C:24:A2:C6:21:80:26:9C:17:9F:CE:5A:B2:36:A0:98:E8:8E
+        Signature Algorithm: ecdsa-with-SHA256
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+            X509v3 Subject Alternative Name: 
+                DNS:ecdsa.tardigrade.test
+    Signature Algorithm: ecdsa-with-SHA256

--- a/docs/evidence/f05-672/live-cert-rsa.tardigrade.test.txt
+++ b/docs/evidence/f05-672/live-cert-rsa.tardigrade.test.txt
@@ -1,0 +1,25 @@
+$ openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername rsa.tardigrade.test -alpn http/1.1 -showcerts </dev/null
+Connecting to 127.0.0.1
+8030D2FF01000000:error:0A000438:SSL routines:ssl3_read_bytes:tlsv1 alert internal error:ssl/record/rec_layer_s3.c:918:SSL alert number 80
+CONNECTED(00000003)
+---
+no peer certificate available
+---
+No client certificate CA names sent
+Negotiated TLS1.3 group: <NULL>
+---
+SSL handshake has read 7 bytes and written 1492 bytes
+Verification: OK
+---
+New, (NONE), Cipher is (NONE)
+Protocol: TLSv1.3
+This TLS version forbids renegotiation.
+Compression: NONE
+Expansion: NONE
+No ALPN negotiated
+Early data was not sent
+Verify return code: 0 (ok)
+---
+8030D2FF01000000:error:0A000197:SSL routines:SSL_shutdown:shutdown while in init:ssl/ssl_lib.c:2804:
+
+$ openssl s_client ... | openssl x509 -noout -subject -issuer -dates -ext subjectAltName -fingerprint -sha256 -text

--- a/docs/evidence/f05-672/live-cert-tardigrade.test.txt
+++ b/docs/evidence/f05-672/live-cert-tardigrade.test.txt
@@ -1,0 +1,62 @@
+$ openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn http/1.1 -showcerts </dev/null
+Connecting to 127.0.0.1
+depth=0 CN=tardigrade.test
+verify error:num=18:self-signed certificate
+verify return:1
+depth=0 CN=tardigrade.test
+verify return:1
+CONNECTED(00000003)
+---
+Certificate chain
+ 0 s:CN=tardigrade.test
+   i:CN=tardigrade.test
+   a:PKEY: ED25519, 256 (bit); sigalg: ED25519
+   v:NotBefore: Aug 26 14:03:43 2026 GMT; NotAfter: Sep  2 14:03:43 2026 GMT
+-----BEGIN CERTIFICATE-----
+MIIBbjCCASCgAwIBAgIUX+nFOrnkozGdc0vSEkR3+ef09JQwBQYDK2VwMBoxGDAW
+BgNVBAMMD3RhcmRpZ3JhZGUudGVzdDAeFw0yNjA4MjYxNDAzNDNaFw0yNjA5MDIx
+NDAzNDNaMBoxGDAWBgNVBAMMD3RhcmRpZ3JhZGUudGVzdDAqMAUGAytlcAMhADpc
+D6ltRlOHoj5t+1ZyDTYRleiy3k7zfkT4tCsBAVxDo3gwdjAzBgNVHREELDAqgg90
+YXJkaWdyYWRlLnRlc3SCF2RlZmF1bHQudGFyZGlncmFkZS50ZXN0MAsGA1UdDwQE
+AwIHgDATBgNVHSUEDDAKBggrBgEFBQcDATAdBgNVHQ4EFgQUXbkDv0ilEVr0Db74
+KcQ0pLfFch4wBQYDK2VwA0EAopVdAy4BQWCvTu/ZuMB2Mqoi3b9iD4TYcyy4Xhjd
+G54bIHvKwcrzvyla1kotB+cPYjYzRKlYln1FPPM8araUBQ==
+-----END CERTIFICATE-----
+---
+Server certificate
+subject=CN=tardigrade.test
+issuer=CN=tardigrade.test
+---
+No client certificate CA names sent
+Peer signature type: ed25519
+Peer Temp Key: X25519, 253 bits
+---
+SSL handshake has read 683 bytes and written 1552 bytes
+Verification error: self-signed certificate
+---
+New, TLSv1.3, Cipher is TLS_AES_128_GCM_SHA256
+Protocol: TLSv1.3
+Server public key is 256 bit
+This TLS version forbids renegotiation.
+Compression: NONE
+Expansion: NONE
+ALPN protocol: http/1.1
+Early data was not sent
+Verify return code: 18 (self-signed certificate)
+---
+DONE
+
+$ openssl s_client ... | openssl x509 -noout -subject -issuer -dates -ext subjectAltName -fingerprint -sha256 -text
+subject=CN=tardigrade.test
+issuer=CN=tardigrade.test
+notBefore=Aug 26 14:03:43 2026 GMT
+notAfter=Sep  2 14:03:43 2026 GMT
+X509v3 Subject Alternative Name: 
+    DNS:tardigrade.test, DNS:default.tardigrade.test
+sha256 Fingerprint=CF:CF:54:B1:3F:77:AA:C7:27:08:F6:3C:22:2E:15:09:E1:95:08:9C:CA:30:2E:47:63:E2:40:E1:E6:34:10:FA
+        Signature Algorithm: ED25519
+            Public Key Algorithm: ED25519
+                ED25519 Public-Key:
+            X509v3 Subject Alternative Name: 
+                DNS:tardigrade.test, DNS:default.tardigrade.test
+    Signature Algorithm: ED25519

--- a/docs/evidence/f05-672/openssl-alpn-cipher-enum.sh
+++ b/docs/evidence/f05-672/openssl-alpn-cipher-enum.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env sh
+set -eu
+
+OPENSSL_BIN="${OPENSSL_BIN:-openssl}"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-18443}"
+SNI="${SNI:-tardigrade.test}"
+ALPN="${ALPN:-http/1.1}"
+
+run_probe() {
+    name="$1"
+    shift
+    printf '\n## %s\n' "$name"
+    printf '$'
+    for arg in "$@"; do
+        printf ' %s' "$arg"
+    done
+    printf '\n'
+    if "$@" </dev/null 2>&1; then
+        printf 'RESULT: success\n'
+    else
+        code="$?"
+        printf 'RESULT: failure exit=%s\n' "$code"
+    fi
+}
+
+printf '# OpenSSL ALPN cipher/protocol enumeration\n'
+printf 'openssl=%s\n' "$("$OPENSSL_BIN" version)"
+printf 'target=%s:%s\n' "$HOST" "$PORT"
+printf 'sni=%s\n' "$SNI"
+printf 'alpn=%s\n' "$ALPN"
+
+printf '\n# Local TLS 1.3 ciphersuites enumerated by OpenSSL\n'
+"$OPENSSL_BIN" ciphers -tls1_3 -stdname -s -V
+
+run_probe tls13_tls_aes_256_gcm_sha384 \
+    "$OPENSSL_BIN" s_client -connect "$HOST:$PORT" -tls1_3 \
+    -servername "$SNI" -alpn "$ALPN" \
+    -ciphersuites TLS_AES_256_GCM_SHA384 -brief
+
+run_probe tls13_tls_chacha20_poly1305_sha256 \
+    "$OPENSSL_BIN" s_client -connect "$HOST:$PORT" -tls1_3 \
+    -servername "$SNI" -alpn "$ALPN" \
+    -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -brief
+
+run_probe tls13_tls_aes_128_gcm_sha256 \
+    "$OPENSSL_BIN" s_client -connect "$HOST:$PORT" -tls1_3 \
+    -servername "$SNI" -alpn "$ALPN" \
+    -ciphersuites TLS_AES_128_GCM_SHA256 -brief
+
+run_probe tls12 \
+    "$OPENSSL_BIN" s_client -connect "$HOST:$PORT" -tls1_2 \
+    -servername "$SNI" -alpn "$ALPN" -brief
+
+run_probe tls11 \
+    "$OPENSSL_BIN" s_client -connect "$HOST:$PORT" -tls1_1 \
+    -servername "$SNI" -brief
+
+run_probe tls10 \
+    "$OPENSSL_BIN" s_client -connect "$HOST:$PORT" -tls1 \
+    -servername "$SNI" -brief

--- a/docs/evidence/f05-672/openssl-alpn-cipher-enum.txt
+++ b/docs/evidence/f05-672/openssl-alpn-cipher-enum.txt
@@ -1,0 +1,61 @@
+# OpenSSL ALPN cipher/protocol enumeration
+openssl=OpenSSL 3.6.3 9 Jun 2026 (Library: OpenSSL 3.6.3 9 Jun 2026)
+target=127.0.0.1:18443
+sni=tardigrade.test
+alpn=http/1.1
+
+# Local TLS 1.3 ciphersuites enumerated by OpenSSL
+          0x13,0x02 - TLS_AES_256_GCM_SHA384                        - TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD
+          0x13,0x03 - TLS_CHACHA20_POLY1305_SHA256                  - TLS_CHACHA20_POLY1305_SHA256   TLSv1.3 Kx=any      Au=any   Enc=CHACHA20/POLY1305(256) Mac=AEAD
+          0x13,0x01 - TLS_AES_128_GCM_SHA256                        - TLS_AES_128_GCM_SHA256         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(128)            Mac=AEAD
+
+## tls13_tls_aes_256_gcm_sha384
+$ /opt/homebrew/bin/openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn http/1.1 -ciphersuites TLS_AES_256_GCM_SHA384 -brief
+Connecting to 127.0.0.1
+8030D2FF01000000:error:0A000410:SSL routines:ssl3_read_bytes:ssl/tls alert handshake failure:ssl/record/rec_layer_s3.c:918:SSL alert number 40
+8030D2FF01000000:error:0A000197:SSL routines:SSL_shutdown:shutdown while in init:ssl/ssl_lib.c:2804:
+RESULT: failure exit=1
+
+## tls13_tls_chacha20_poly1305_sha256
+$ /opt/homebrew/bin/openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn http/1.1 -ciphersuites TLS_CHACHA20_POLY1305_SHA256 -brief
+Connecting to 127.0.0.1
+8030D2FF01000000:error:0A000410:SSL routines:ssl3_read_bytes:ssl/tls alert handshake failure:ssl/record/rec_layer_s3.c:918:SSL alert number 40
+8030D2FF01000000:error:0A000197:SSL routines:SSL_shutdown:shutdown while in init:ssl/ssl_lib.c:2804:
+RESULT: failure exit=1
+
+## tls13_tls_aes_128_gcm_sha256
+$ /opt/homebrew/bin/openssl s_client -connect 127.0.0.1:18443 -tls1_3 -servername tardigrade.test -alpn http/1.1 -ciphersuites TLS_AES_128_GCM_SHA256 -brief
+Connecting to 127.0.0.1
+depth=0 CN=tardigrade.test
+verify error:num=18:self-signed certificate
+CONNECTION ESTABLISHED
+Protocol version: TLSv1.3
+Ciphersuite: TLS_AES_128_GCM_SHA256
+Peer certificate: CN=tardigrade.test
+Hash used: UNDEF
+Signature type: ed25519
+Verification error: self-signed certificate
+Peer Temp Key: X25519, 253 bits
+DONE
+RESULT: success
+
+## tls12
+$ /opt/homebrew/bin/openssl s_client -connect 127.0.0.1:18443 -tls1_2 -servername tardigrade.test -alpn http/1.1 -brief
+Connecting to 127.0.0.1
+8030D2FF01000000:error:0A00042E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version:ssl/record/rec_layer_s3.c:918:SSL alert number 70
+8030D2FF01000000:error:0A000197:SSL routines:SSL_shutdown:shutdown while in init:ssl/ssl_lib.c:2804:
+RESULT: failure exit=1
+
+## tls11
+$ /opt/homebrew/bin/openssl s_client -connect 127.0.0.1:18443 -tls1_1 -servername tardigrade.test -brief
+Connecting to 127.0.0.1
+8030D2FF01000000:error:0A0000BF:SSL routines:tls_setup_handshake:no protocols available:ssl/statem/statem_lib.c:155:
+8030D2FF01000000:error:0A000197:SSL routines:SSL_shutdown:shutdown while in init:ssl/ssl_lib.c:2804:
+RESULT: failure exit=1
+
+## tls10
+$ /opt/homebrew/bin/openssl s_client -connect 127.0.0.1:18443 -tls1 -servername tardigrade.test -brief
+Connecting to 127.0.0.1
+8030D2FF01000000:error:0A0000BF:SSL routines:tls_setup_handshake:no protocols available:ssl/statem/statem_lib.c:155:
+8030D2FF01000000:error:0A000197:SSL routines:SSL_shutdown:shutdown while in init:ssl/ssl_lib.c:2804:
+RESULT: failure exit=1

--- a/docs/evidence/f05-672/testssl.json
+++ b/docs/evidence/f05-672/testssl.json
@@ -1,0 +1,65 @@
+{
+          "clientProblem1" : [
+                            {
+                                "id"           : "engine_problem",
+                                "severity"     : "WARN",
+                                "finding"      : "No engine or GOST support via engine with your /opt/homebrew/bin/openssl"
+                           }
+          ],
+          "clientProblem2" : [
+                            {
+                                "id"           : "cmdline_ip-target",
+                                "severity"     : "WARN",
+                                "finding"      : "Target is not a server name: results may be completely wrong, at minimum trust may show false results."
+                           }
+          ],
+          "Invocation"  : "testssl.sh --protocols --server-preference --cipher-per-proto --jsonfile-pretty /tmp/tardigrade-f05-672.YhJ4lO/artifacts/testssl-2.json --logfile /tmp/tardigrade-f05-672.YhJ4lO/artifacts/testssl-2.log --warnings batch 127.0.0.1:18443",
+          "at"          : "Joes-MacBook-Air:/opt/homebrew/bin/openssl",
+          "version"     : "3.3dev d2bc042d",
+          "openssl"     : "OpenSSL 3.6.3 from Tue Jun 9 11:46:57 2026",
+          "startTime"   : "1787753205",
+          "scanResult"  : [
+          {
+                    "targetHost"      : "127.0.0.1",
+                    "ip"              : "127.0.0.1",
+                    "port"            : "18443",
+                    "rDNS"            : "localhost",
+                    "service"         : "Couldn't determine service, skipping all HTTP checks",
+                    "pretest"           : [
+                            {
+                                "id"           : "pre_128cipher",
+                                "severity"     : "INFO",
+                                "finding"      : "No 128 cipher limit bug"
+                           }
+                    ],
+                    "protocols"         : [
+                            {
+                                "id"           : "SSLv2",
+                                "severity"     : "OK",
+                                "finding"      : "not offered"
+                           },{
+                                "id"           : "SSLv3",
+                                "severity"     : "OK",
+                                "finding"      : "not offered"
+                           },{
+                                "id"           : "TLS1",
+                                "severity"     : "INFO",
+                                "finding"      : "not offered"
+                           },{
+                                "id"           : "TLS1_1",
+                                "severity"     : "INFO",
+                                "finding"      : "not offered"
+                           },{
+                                "id"           : "TLS1_2",
+                                "severity"     : "MEDIUM",
+                                "finding"      : "not offered"
+                           },{
+                                "id"           : "TLS1_3",
+                                "severity"     : "LOW",
+                                "finding"      : "not offered"
+                           }
+                    ]
+          }
+          ],
+                    "scanTime"  : "Scan interrupted"
+}

--- a/docs/evidence/f05-672/testssl.log
+++ b/docs/evidence/f05-672/testssl.log
@@ -1,0 +1,22 @@
+## Scan started as: "testssl.sh --protocols --server-preference --cipher-per-proto --jsonfile-pretty /tmp/tardigrade-f05-672.YhJ4lO/artifacts/testssl-2.json --logfile /tmp/tardigrade-f05-672.YhJ4lO/artifacts/testssl-2.log --warnings batch 127.0.0.1:18443"
+## at Joes-MacBook-Air:/opt/homebrew/bin/openssl
+## version testssl: 3.3dev d2bc042d from 2026-08-26
+## version openssl: "3.6.3" from "Tue Jun 9 11:46:57 2026")
+
+[1mTesting all IPv4 addresses (port 18443): [m127.0.0.1
+-----------------------------------------------------
+[7m Start 2026-08-26 10:06:47        -->> 127.0.0.1:18443 (127.0.0.1) <<--[m
+
+[1m rDNS [m(127.0.0.1):       localhost
+[1m Service detected:[m       Couldn't determine what's running on port 18443, assuming no HTTP service => skipping all HTTP checks
+
+[1m[4m Testing protocols [m[4mvia sockets except NPN+ALPN [m
+
+[1m SSLv2      [m[1;32mnot offered (OK)[m
+[1m SSLv3      [m[1;32mnot offered (OK)[m
+[1m TLS 1      [mnot offered
+[1m TLS 1.1    [mnot offered
+[1m TLS 1.2    [m[0;33mnot offered[m
+[1m TLS 1.3    [m[1;33mnot offered[m
+
+

--- a/docs/evidence/f05-672/tls-nmap.txt
+++ b/docs/evidence/f05-672/tls-nmap.txt
@@ -1,0 +1,10 @@
+$ nmap -Pn -sV --version-all --script +ssl-enum-ciphers --script-args tls.servername=tardigrade.test -p 18443 -oX tls-nmap.xml 127.0.0.1
+Starting Nmap 7.98 ( https://nmap.org ) at 2026-08-26 10:05 -0400
+Nmap scan report for localhost (127.0.0.1)
+Host is up (0.00013s latency).
+
+PORT      STATE SERVICE VERSION
+18443/tcp open  unknown
+
+Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
+Nmap done: 1 IP address (1 host up) scanned in 45.25 seconds

--- a/docs/evidence/f05-672/tls-nmap.xml
+++ b/docs/evidence/f05-672/tls-nmap.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nmaprun>
+<?xml-stylesheet href="file:///opt/homebrew/bin/../share/nmap/nmap.xsl" type="text/xsl"?>
+<!-- Nmap 7.98 scan initiated Wed Aug 26 10:05:00 2026 as: nmap -Pn -sV -&#45;version-all -&#45;script +ssl-enum-ciphers -&#45;script-args tls.servername=tardigrade.test -p 18443 -oX /tmp/tardigrade-f05-672.YhJ4lO/artifacts/tls-nmap.xml 127.0.0.1 -->
+<nmaprun scanner="nmap" args="nmap -Pn -sV -&#45;version-all -&#45;script +ssl-enum-ciphers -&#45;script-args tls.servername=tardigrade.test -p 18443 -oX /tmp/tardigrade-f05-672.YhJ4lO/artifacts/tls-nmap.xml 127.0.0.1" start="1787753100" startstr="Wed Aug 26 10:05:00 2026" version="7.98" xmloutputversion="1.05">
+<scaninfo type="connect" protocol="tcp" numservices="1" services="18443"/>
+<verbose level="0"/>
+<debugging level="0"/>
+<host starttime="1787753100" endtime="1787753146"><status state="up" reason="user-set" reason_ttl="0"/>
+<address addr="127.0.0.1" addrtype="ipv4"/>
+<hostnames>
+<hostname name="localhost" type="PTR"/>
+</hostnames>
+<ports><port protocol="tcp" portid="18443"><state state="open" reason="syn-ack" reason_ttl="0"/></port>
+</ports>
+<times srtt="125" rttvar="5000" to="100000"/>
+</host>
+<runstats><finished time="1787753146" timestr="Wed Aug 26 10:05:46 2026" summary="Nmap done at Wed Aug 26 10:05:46 2026; 1 IP address (1 host up) scanned in 45.25 seconds" elapsed="45.25" exit="success"/><hosts up="1" down="0" total="1"/>
+</runstats>
+</nmaprun>


### PR DESCRIPTION
## Summary

- adds sanitized F-05 live native TLS surface evidence for #672
- records the local scanner pass, scanner ALPN limitation, OpenSSL/nghttp manual probe matrix, public cert metadata, and live shutdown/truncation observations
- moves F-05 from open to resolved in `docs/SECURITY_TEST_PLAN.md`

## Validation

- `zig build test-tls --summary all --error-style verbose` — passed, 1035/1035
- `zig build test-integration-native-tls --summary all --error-style verbose` — passed, 19/24 passed, 5 skipped
- `zig build test-integration --summary all --error-style verbose` — first full run failed in three pre-existing/flaky-looking cases; each failed case passed when rerun directly, and the second full run passed, 174/193 passed, 19 skipped

Closes #672
