### PR TITLE
ci: verify v0.6.x Linux archives on Ubuntu 22.04 and Rocky 9

### DIFF
--- a/.github/workflows/linux-release-smoke.yml
+++ b/.github/workflows/linux-release-smoke.yml
@@ -1,0 +1,122 @@
+name: Linux Release Smoke
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/linux-release-smoke.yml"
+      - ".github/workflows/release.yml"
+      - "build.zig"
+      - "build.zig.zon"
+      - "src/**"
+      - "scripts/install-zig.sh"
+      - "scripts/verify-linux-compatibility.sh"
+      - "scripts/audit-release-binary.sh"
+      - "scripts/package-release-archive.sh"
+      - "packaging/**"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Published release tag to verify
+        required: true
+        default: v0.6.2
+
+permissions:
+  contents: read
+
+concurrency:
+  group: linux-release-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux-release-smoke:
+    name: Linux release smoke (${{ matrix.distro }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - archive_name: tardigrade-linux-x86_64
+            zig_target: x86_64-linux-gnu.2.28
+            distro: ubuntu:22.04
+          - archive_name: tardigrade-linux-x86_64
+            zig_target: x86_64-linux-gnu.2.28
+            distro: rockylinux:9
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Zig
+        if: github.event_name == 'pull_request'
+        run: sh ./scripts/install-zig.sh 0.16.0
+
+      - name: Print Zig version
+        if: github.event_name == 'pull_request'
+        run: zig version
+
+      - name: Build native release binary
+        if: github.event_name == 'pull_request'
+        env:
+          ZIG_TARGET: ${{ matrix.zig_target }}
+        run: |
+          zig build -Doptimize=ReleaseFast -Dcpu=baseline "-Dtarget=$ZIG_TARGET" -Dversion=0.0.0-ci-smoke
+
+      - name: Audit native release binary linkage
+        if: github.event_name == 'pull_request'
+        run: |
+          ./scripts/audit-release-binary.sh \
+            --binary zig-out/bin/tardi \
+            --profile general \
+            --output "$RUNNER_TEMP/dependency-inventory-${{ matrix.archive_name }}.json"
+
+      - name: Package artifact
+        if: github.event_name == 'pull_request'
+        env:
+          ARCHIVE_NAME: ${{ matrix.archive_name }}
+        run: |
+          ./scripts/package-release-archive.sh \
+            --archive-name "$ARCHIVE_NAME" \
+            --binary zig-out/bin/tardi \
+            --staging-dir dist \
+            --output-dir "$RUNNER_TEMP/release-artifacts"
+
+      - name: Setup PR expected version
+        if: github.event_name == 'pull_request'
+        run: echo "EXPECTED_VERSION=0.0.0-ci-smoke" >> "$GITHUB_ENV"
+
+      - name: Resolve published release identity
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          git fetch --force origin "refs/tags/$TAG:refs/tags/$TAG"
+          release_sha="$(git rev-list -n 1 "$TAG")"
+          expected_version="${TAG#v}"
+          printf 'published_tag=%s\n' "$TAG"
+          printf 'expected_version=%s\n' "$expected_version"
+          printf 'source_commit_sha=%s\n' "$release_sha"
+          printf 'EXPECTED_VERSION=%s\n' "$expected_version" >> "$GITHUB_ENV"
+
+      - name: Download published release asset
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+          ARCHIVE_NAME: ${{ matrix.archive_name }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/release-artifacts"
+          gh release download "$TAG" -p "${ARCHIVE_NAME}.tar.gz" -D "$RUNNER_TEMP/release-artifacts"
+
+      - name: Verify compatibility on ${{ matrix.distro }}
+        env:
+          ARCHIVE_NAME: ${{ matrix.archive_name }}
+          DISTRO: ${{ matrix.distro }}
+        run: |
+          ./scripts/verify-linux-compatibility.sh \
+            "$DISTRO" \
+            "$RUNNER_TEMP/release-artifacts/$ARCHIVE_NAME.tar.gz" \
+            "$EXPECTED_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,11 +344,59 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  verify-linux-archive:
+    name: Verify ${{ matrix.archive_name }} on ${{ matrix.distro }}
+    needs:
+      - prepare-release
+      - build-release
+    if: needs.prepare-release.result == 'success' && needs.prepare-release.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - archive_name: tardigrade-linux-x86_64
+            distro: ubuntu:22.04
+          - archive_name: tardigrade-linux-x86_64
+            distro: rockylinux:9
+
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_sha }}
+          persist-credentials: false
+
+      - name: Download archive artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ matrix.archive_name }}
+          path: ${{ runner.temp }}/verify-artifacts
+
+      - name: Verify compatibility on ${{ matrix.distro }}
+        env:
+          ARCHIVE_NAME: ${{ matrix.archive_name }}
+          DISTRO: ${{ matrix.distro }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+          EXPECTED_VERSION: ${{ needs.prepare-release.outputs.version }}
+          RELEASE_SHA: ${{ needs.prepare-release.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          printf 'candidate_tag=%s\n' "$RELEASE_TAG"
+          printf 'expected_version=%s\n' "$EXPECTED_VERSION"
+          printf 'source_commit_sha=%s\n' "$RELEASE_SHA"
+          ./scripts/verify-linux-compatibility.sh \
+            "$DISTRO" \
+            "$RUNNER_TEMP/verify-artifacts/$ARCHIVE_NAME.tar.gz" \
+            "$EXPECTED_VERSION"
+
   publish-release:
     name: Publish GitHub release assets
     needs:
       - prepare-release
       - build-release
+      - verify-linux-archive
     if: needs.prepare-release.result == 'success' && needs.prepare-release.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes to Tardigrade are documented here.
 
 ## [Unreleased]
 
+### Testing
+- **Linux release archive compatibility verification (#671)** — adds a new blocking `verify-linux-archive` job to the release CI pipeline that ensures `linux-x86_64` `.tar.gz` release artifacts can successfully start, serve traffic, and gracefully shut down on the project's required older userlands (Ubuntu 22.04 LTS and Rocky Linux 9). Release builds remain pinned to the `x86_64-linux-gnu.2.28` target, and a pull-request `linux-release-smoke.yml` workflow catches linkage or runtime regressions before merge.
+
 ## [0.6.2] - 2026-08-25
 
 ### Fixed

--- a/scripts/audit-dependencies.sh
+++ b/scripts/audit-dependencies.sh
@@ -682,7 +682,7 @@ is_allowed_metadata_dependency_statement() {
             case "$token" in
             '&&' | ';' | '|' | '||') break ;;
             -*) continue ;;
-            ca-certificates | curl | xz-utils | rpm)
+            ca-certificates | curl | xz-utils | rpm | file | binutils)
                 seen_package=true
                 ;;
             *)

--- a/scripts/verify-linux-compatibility.sh
+++ b/scripts/verify-linux-compatibility.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env sh
+set -eu
+
+[ "$#" -eq 3 ] || {
+    echo "Usage: $0 <docker-image> <archive-path> <expected-version>" >&2
+    exit 2
+}
+
+image="$1"
+archive_dir=$(cd "$(dirname "$2")" && pwd -P)
+archive="$archive_dir/$(basename "$2")"
+expected_version="$3"
+
+test -f "$archive" || { echo "archive not found: $archive" >&2; exit 2; }
+
+archive_sha=$(sha256sum "$archive" | awk '{print $1}')
+printf 'archive=%s\narchive_sha256=%s\n' "$(basename "$archive")" "$archive_sha"
+
+docker pull --platform linux/amd64 "$image"
+docker image inspect --format 'image={{index .RepoDigests 0}}' "$image"
+
+echo "Verifying $archive in $image"
+
+docker run --rm --platform linux/amd64 \
+    -e EXPECTED_VERSION="$expected_version" \
+    -v "$archive:/artifact.tar.gz:ro" \
+    "$image" \
+    /bin/sh -euxc '
+    if command -v apt-get >/dev/null 2>&1; then
+        apt-get update
+        apt-get install -y curl ca-certificates file binutils
+    elif command -v dnf >/dev/null 2>&1; then
+        dnf install -y ca-certificates file binutils
+        if ! command -v curl >/dev/null 2>&1; then
+            dnf install -y curl-minimal
+        fi
+    else
+        echo "No supported package manager found" >&2
+        exit 1
+    fi
+
+    mkdir -p /tmp/ext
+    cd /tmp/ext
+    tar -xzf /artifact.tar.gz
+
+    if [ ! -x ./tardi ]; then
+        echo "archive does not contain executable root-level tardi" >&2
+        exit 1
+    fi
+    if [ ! -L ./tardigrade ]; then
+        echo "archive does not contain tardigrade symlink" >&2
+        exit 1
+    fi
+    link_target=$(readlink ./tardigrade)
+    if [ "$link_target" != "tardi" ]; then
+        echo "unexpected tardigrade symlink target: $link_target (expected tardi)" >&2
+        exit 1
+    fi
+
+    tardi=./tardi
+
+    cat /etc/os-release
+    uname -m
+    getconf GNU_LIBC_VERSION || true
+    ldd --version
+    file "$tardi"
+    ldd "$tardi"
+    readelf --version-info "$tardi"
+    
+    printf "referenced_glibc_versions:\n"
+    readelf --version-info "$tardi" \
+      | grep -oE "GLIBC_[0-9]+(\.[0-9]+)*" \
+      | sort -Vu \
+      | sed "s/^/  /"
+    
+    version_output=$("$tardi" version)
+    printf "tardi_version=%s\n" "$version_output"
+    
+    expected="$EXPECTED_VERSION (tls-profile=general, tls-backend=native)"
+    if [ "$version_output" != "$expected" ]; then
+        echo "unexpected tardi version identity" >&2
+        echo "expected: $expected" >&2
+        echo "actual:   $version_output" >&2
+        exit 1
+    fi
+    
+    cat > tardigrade.conf <<EOF
+listen 18089;
+server_name localhost;
+location = /health {
+    return 200 compat-ok;
+}
+EOF
+    "$tardi" check -c tardigrade.conf
+
+    "$tardi" run -c tardigrade.conf > tardi.log 2>&1 &
+    pid=$!
+
+    ready=false
+    i=0
+    while [ $i -lt 50 ]; do
+        if curl -fsS http://localhost:18089/health >/dev/null 2>&1; then
+            ready=true
+            break
+        fi
+        if ! kill -0 "$pid" >/dev/null 2>&1; then
+            break
+        fi
+        sleep 0.2
+        i=$((i+1))
+    done
+
+    if [ "$ready" != "true" ]; then
+        cat tardi.log >&2
+        echo "Failed to start or serve traffic" >&2
+        exit 1
+    fi
+
+    res=$(curl -fsS http://localhost:18089/health)
+    if [ "$res" != "compat-ok" ]; then
+        echo "Unexpected response: $res" >&2
+        exit 1
+    fi
+
+    kill -INT "$pid"
+    i=0
+    while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 50 ]; do
+        sleep 0.2
+        i=$((i + 1))
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        cat tardi.log >&2
+        kill -KILL "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+        echo "tardi did not exit after SIGINT" >&2
+        exit 1
+    fi
+    if wait "$pid"; then
+        :
+    else
+        status=$?
+        cat tardi.log >&2
+        echo "tardi exited non-zero after SIGINT: $status" >&2
+        exit 1
+    fi
+'


### PR DESCRIPTION
### Description
This PR implements the requested CI verification for Linux release archives to ensure compatibility with older still-relevant glibc userlands (specifically `ubuntu:22.04` and `rockylinux:9`).

### Changes
- **`scripts/verify-linux-compatibility.sh`**: Extracts the `.tar.gz` artifact within an arbitrary Docker image, starts the process, verifies clean shutdown, and asserts `compat-ok` health status.
- **`linux-release-smoke.yml`**: Runs compatibility smoke tests on PRs using `x86_64-linux-gnu.2.28` to catch glibc regressions early.
- **`release.yml`**: Adds a `verify-linux-archive` job that gates `publish-release`, ensuring we test the exact release archive before publishing.

Closes #671
