### PR TITLE
Fix uneven route benchmark concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
           benchmarks/run.sh
           benchmarks/competitive/run.sh
           benchmarks/competitive/netem-impair.sh
+          benchmarks/competitive/upstream-pool-matrix.sh
+          benchmarks/competitive/test-upstream-pool-matrix.sh
           benchmarks/test-h3-benchmark.sh
 
       # A native `zig build` with no explicit -Dcpu embeds the exact CPU
@@ -681,6 +683,9 @@ jobs:
       # coverage.
       - name: Run H3 benchmark harness tests (#256-G)
         run: ./benchmarks/test-h3-benchmark.sh
+
+      - name: Run upstream pool matrix harness tests (#683)
+        run: ./benchmarks/competitive/test-upstream-pool-matrix.sh
 
       - name: Stage perf smoke artifact
         if: always()

--- a/benchmarks/competitive/run.sh
+++ b/benchmarks/competitive/run.sh
@@ -1123,10 +1123,11 @@ write_combined_outputs() {
              (.value.quic.udp_buffers.recv.status // null), (.value.quic.udp_buffers.send.status // null)]),
         (if .upstream_pool_matrix != null then
             (.upstream_pool_matrix.scenarios | to_entries[] |
+                (.value.combined // .value) as $v |
                 ["tardigrade", ("upstream-pool/" + .key), (if .value.covered != null then .value.covered elif .value.supported != null then .value.supported else true end), (.value.reason // .value.sharding_note // null),
-                 (.value.rps // null), null, null, (.value.p99_ms // null), null, (.value.p99_ttfb_ms // null), null,
-                 (.value.cpu_pct_avg // null), (.value.cpu_ms_per_request // null), (.value.rss_mb_peak // null), (.value.open_fds_peak // null), (.value.errors // null),
-                 (.value.pool_lock_wait_ns_per_request // null), (.value.pool_lock_wait_ns_per_acquire // null),
+                 ($v.rps // null), null, null, ($v.p99_ms // null), null, ($v.p99_ttfb_ms // null), null,
+                 ($v.cpu_pct_avg // null), ($v.cpu_ms_per_request // null), ($v.rss_mb_peak // null), ($v.open_fds_peak // null), (.value.errors // $v.errors // null),
+                 ($v.pool_lock_wait_ns_per_request // null), ($v.pool_lock_wait_ns_per_acquire // null),
                  null, null, null, null, null, null, null]),
             (.upstream_pool_matrix.scenarios["uneven-route-distribution"].routes // {} | to_entries[] |
                 ["tardigrade", ("upstream-pool/uneven/" + .key), (if .value.covered == null then true else .value.covered end), (.value.reason // null),
@@ -1191,7 +1192,8 @@ write_combined_outputs() {
             echo "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | --- |"
             jq -r '
                 .upstream_pool_matrix.scenarios | to_entries[] |
-                "| `\(.key)` | \((if .value.covered != null then .value.covered elif .value.supported != null then .value.supported else true end)) | \(.value.rps // "-") | \(.value.p99_ms // "-") | \(.value.p99_ttfb_ms // "-") | \(.value.cpu_pct_avg // "-") | \(.value.cpu_ms_per_request // "-") | \(.value.rss_mb_peak // "-") | \(.value.new_connections_per_sec // "-") | \(.value.reuse_ratio // "-") | \(.value.pool_lock_wait_ns_per_request // "-") | \(.value.sharding_justified // "-") | \(.value.errors // "-") | \(.value.reason // "-") |"
+                (.value.combined // .value) as $v |
+                "| `\(.key)` | \((if .value.covered != null then .value.covered elif .value.supported != null then .value.supported else true end)) | \($v.rps // "-") | \($v.p99_ms // "-") | \($v.p99_ttfb_ms // "-") | \($v.cpu_pct_avg // "-") | \($v.cpu_ms_per_request // "-") | \($v.rss_mb_peak // "-") | \($v.new_connections_per_sec // "-") | \($v.reuse_ratio // "-") | \($v.pool_lock_wait_ns_per_request // "-") | \(.value.sharding_justified // "-") | \(.value.errors // $v.errors // "-") | \(.value.reason // "-") |"
             ' "$combined_json"
             echo ""
             echo "### Upstream Pool Detail Rows"

--- a/benchmarks/competitive/test-upstream-pool-matrix.sh
+++ b/benchmarks/competitive/test-upstream-pool-matrix.sh
@@ -6,9 +6,10 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 SCRIPT_UNDER_TEST="${REPO_ROOT}/benchmarks/competitive/upstream-pool-matrix.sh"
+COMPETITIVE_RUN_SH="${REPO_ROOT}/benchmarks/competitive/run.sh"
 TEST_DIR="$(mktemp -d /tmp/tardigrade-upstream-matrix-test-XXXXXX)"
 
-# shellcheck disable=SC2329 # invoked by trap
+# shellcheck disable=SC2317,SC2329 # invoked by trap; ShellCheck versions differ
 cleanup() {
     rm -rf "$TEST_DIR"
 }
@@ -168,6 +169,7 @@ jq -e '
     and .routes.route_a.achieved_share == 0.8
     and .routes.route_b.achieved_share == 0.15
     and .routes.route_c.achieved_share == 0.05
+    and (.routes.route_a | has("achieved_request_count") | not)
     and .combined.rps == 1000
     and .combined.new_connections == 4
     and .combined.reused_connections == 16
@@ -196,13 +198,32 @@ export WRK_FAIL_ROUTE="route-c"
 if run_concurrent_uneven_routes >"${TEST_DIR}/failed.out" 2>"${TEST_DIR}/failed.err"; then
     fail "failed route process unexpectedly succeeded"
 fi
-grep -q 'concurrent uneven route wrk failed: route-a=0 route-b=0 route-c=17' "${TEST_DIR}/failed.err" || {
+grep -q 'concurrent uneven route wrk failed:' "${TEST_DIR}/failed.err" || {
     cat "${TEST_DIR}/failed.err" >&2
     fail "missing child-status diagnostic"
+}
+grep -q 'route-c=17' "${TEST_DIR}/failed.err" || {
+    cat "${TEST_DIR}/failed.err" >&2
+    fail "missing failed-route status"
 }
 grep -q 'forced failure for route-c' "${TEST_DIR}/failed.err" || {
     cat "${TEST_DIR}/failed.err" >&2
     fail "missing failed-route raw output"
 }
+
+echo "==> Test 4: competitive formatter reads nested combined aggregate metrics"
+# shellcheck disable=SC2016 # matching literal jq source text
+combined_fallbacks="$(grep -cF '(.value.combined // .value) as $v' "$COMPETITIVE_RUN_SH")"
+[[ "$combined_fallbacks" -ge 2 ]] || fail "expected CSV and Markdown upstream aggregate formatters to bind combined fallback"
+# shellcheck disable=SC2016 # matching literal jq source text
+grep -qF '($v.rps // null)' "$COMPETITIVE_RUN_SH" || fail "CSV upstream aggregate formatter does not read RPS from combined fallback"
+# shellcheck disable=SC2016 # matching literal jq source text
+grep -qF '($v.cpu_pct_avg // null)' "$COMPETITIVE_RUN_SH" || fail "CSV upstream aggregate formatter does not read CPU from combined fallback"
+# shellcheck disable=SC2016 # matching literal jq source text
+grep -qF '$v.new_connections_per_sec' "$COMPETITIVE_RUN_SH" || fail "Markdown upstream aggregate formatter does not read connection metrics from combined fallback"
+# shellcheck disable=SC2016 # matching literal jq source text
+grep -qF '$v.reuse_ratio' "$COMPETITIVE_RUN_SH" || fail "Markdown upstream aggregate formatter does not read reuse metrics from combined fallback"
+# shellcheck disable=SC2016 # matching literal jq source text
+grep -qF '$v.pool_lock_wait_ns_per_request' "$COMPETITIVE_RUN_SH" || fail "Markdown upstream aggregate formatter does not read lock metrics from combined fallback"
 
 echo "PASS: upstream-pool matrix concurrent route tests"

--- a/benchmarks/competitive/test-upstream-pool-matrix.sh
+++ b/benchmarks/competitive/test-upstream-pool-matrix.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Deterministic harness tests for upstream-pool-matrix.sh's concurrent uneven
+# route scenario. This intentionally avoids starting Tardigrade.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT_UNDER_TEST="${REPO_ROOT}/benchmarks/competitive/upstream-pool-matrix.sh"
+TEST_DIR="$(mktemp -d /tmp/tardigrade-upstream-matrix-test-XXXXXX)"
+
+# shellcheck disable=SC2329 # invoked by trap
+cleanup() {
+    rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+mkdir -p "${TEST_DIR}/bin"
+cat > "${TEST_DIR}/bin/wrk" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${@: -1}"
+route="${url##*/}"
+record_dir="${WRK_TEST_DIR:?WRK_TEST_DIR is required}"
+
+python3 - "$record_dir" "$route" start "$*" <<'PY'
+import pathlib, sys, time
+root = pathlib.Path(sys.argv[1])
+route = sys.argv[2]
+kind = sys.argv[3]
+args = sys.argv[4]
+(root / f"{route}.{kind}").write_text(str(time.monotonic_ns()))
+(root / f"{route}.args").write_text(args)
+PY
+
+touch "${record_dir}/${route}.ready"
+for _ in $(seq 1 100); do
+    if [[ -f "${record_dir}/route-a.ready" && -f "${record_dir}/route-b.ready" && -f "${record_dir}/route-c.ready" ]]; then
+        break
+    fi
+    sleep 0.02
+done
+[[ -f "${record_dir}/route-a.ready" && -f "${record_dir}/route-b.ready" && -f "${record_dir}/route-c.ready" ]] || {
+    echo "barrier timed out for ${route}" >&2
+    exit 9
+}
+
+sleep 0.05
+python3 - "$record_dir" "$route" complete "$*" <<'PY'
+import pathlib, sys, time
+root = pathlib.Path(sys.argv[1])
+route = sys.argv[2]
+kind = sys.argv[3]
+(root / f"{route}.{kind}").write_text(str(time.monotonic_ns()))
+PY
+
+if [[ "${WRK_FAIL_ROUTE:-}" == "$route" ]]; then
+    echo "forced failure for ${route}" >&2
+    exit 17
+fi
+if [[ "${WRK_MALFORMED_ROUTE:-}" == "$route" ]]; then
+    echo "missing summary for ${route}"
+    exit 0
+fi
+
+case "$route" in
+    route-a) echo 'WRK_SUMMARY {"rps":800,"p99_ms":4.2}' ;;
+    route-b) echo 'WRK_SUMMARY {"rps":150,"p99_ms":4.8}' ;;
+    route-c) echo 'WRK_SUMMARY {"rps":50,"p99_ms":5.1}' ;;
+    *) echo "unexpected route: ${route}" >&2; exit 2 ;;
+esac
+SH
+chmod +x "${TEST_DIR}/bin/wrk"
+
+# shellcheck source=benchmarks/competitive/upstream-pool-matrix.sh
+source "$SCRIPT_UNDER_TEST"
+
+PATH="${TEST_DIR}/bin:${PATH}"
+TMP_DIR="${TEST_DIR}/scenario"
+BENCH_DIR="${REPO_ROOT}/benchmarks"
+LISTEN_PORT="19180"
+DURATION="7"
+METRICS_COUNTER_FILE="${TEST_DIR}/metrics-count"
+mkdir -p "$TMP_DIR"
+
+current_metrics() {
+    local count
+    count="$(cat "$METRICS_COUNTER_FILE" 2>/dev/null || printf '0')"
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$METRICS_COUNTER_FILE"
+    if [[ "$count" -eq 1 ]]; then
+        cat <<'EOF'
+tardigrade_upstream_connections_new_total 10
+tardigrade_upstream_connections_reused_total 20
+tardigrade_upstream_connections_reused_local_total 15
+tardigrade_upstream_connections_reused_cross_worker_total 5
+tardigrade_upstream_stale_retries_total 1
+tardigrade_upstream_pool_lock_wait_ns_total 100
+tardigrade_upstream_pool_lock_acquires_total 2
+EOF
+    else
+        cat <<'EOF'
+tardigrade_upstream_connections_new_total 14
+tardigrade_upstream_connections_reused_total 36
+tardigrade_upstream_connections_reused_local_total 25
+tardigrade_upstream_connections_reused_cross_worker_total 11
+tardigrade_upstream_stale_retries_total 1
+tardigrade_upstream_pool_lock_wait_ns_total 5100
+tardigrade_upstream_pool_lock_acquires_total 12
+EOF
+    fi
+}
+
+start_monitor() {
+    printf '123 %s 1.000000 1000000000\n' "${TEST_DIR}/monitor.samples"
+}
+
+stop_monitor() {
+    printf '12.50 34.00 56\n'
+}
+
+monotonic_ns() {
+    printf '3000000000\n'
+}
+
+reset_scenario_state() {
+    rm -f "${TEST_DIR}"/route-*.* "${TEST_DIR}"/scenario/* 2>/dev/null || true
+    printf '0\n' > "$METRICS_COUNTER_FILE"
+}
+
+assert_concurrent_window() {
+    python3 - "$TEST_DIR" <<'PY'
+import pathlib, sys
+root = pathlib.Path(sys.argv[1])
+starts = [int((root / f"route-{r}.start").read_text()) for r in "abc"]
+completes = [int((root / f"route-{r}.complete").read_text()) for r in "abc"]
+if max(starts) > min(completes):
+    raise SystemExit(f"routes did not overlap: starts={starts} completes={completes}")
+PY
+}
+
+echo "==> Test 1: uneven route scenario launches route-a/b/c concurrently and attributes results"
+reset_scenario_state
+export WRK_TEST_DIR="$TEST_DIR"
+unset WRK_FAIL_ROUTE WRK_MALFORMED_ROUTE
+result="$(run_concurrent_uneven_routes)"
+assert_concurrent_window
+metrics_calls="$(cat "$METRICS_COUNTER_FILE")"
+[[ "$metrics_calls" -eq 2 ]] || fail "expected two metrics snapshots, got ${metrics_calls}"
+jq -e '
+    .covered == true
+    and .concurrent == true
+    and .routes.route_a.rps == 800
+    and .routes.route_b.rps == 150
+    and .routes.route_c.rps == 50
+    and .routes.route_a.p99_ms == 4.2
+    and .routes.route_b.p99_ms == 4.8
+    and .routes.route_c.p99_ms == 5.1
+    and .routes.route_a.configured_duration_s == 7
+    and .routes.route_a.configured_connections == 16
+    and .routes.route_b.configured_connections == 3
+    and .routes.route_c.configured_connections == 1
+    and .routes.route_a.achieved_share == 0.8
+    and .routes.route_b.achieved_share == 0.15
+    and .routes.route_c.achieved_share == 0.05
+    and .combined.rps == 1000
+    and .combined.new_connections == 4
+    and .combined.reused_connections == 16
+    and .combined.local_reuse == 10
+    and .combined.cross_worker_reuse == 6
+    and .combined.pool_lock_wait_ns_total == 5000
+    and .errors == 0
+' <<<"$result" >/dev/null || fail "unexpected success JSON: ${result}"
+! grep -R '/hot' "$TEST_DIR"/route-*.args >/dev/null || fail "route-a aliased or invoked the hot-origin path"
+
+echo "==> Test 2: malformed route output fails loudly"
+reset_scenario_state
+export WRK_MALFORMED_ROUTE="route-b"
+if run_concurrent_uneven_routes >"${TEST_DIR}/malformed.out" 2>"${TEST_DIR}/malformed.err"; then
+    fail "malformed route output unexpectedly succeeded"
+fi
+grep -q 'missing wrk summary for route-b' "${TEST_DIR}/malformed.err" || {
+    cat "${TEST_DIR}/malformed.err" >&2
+    fail "missing malformed-output diagnostic"
+}
+
+echo "==> Test 3: non-zero route process status fails and reports raw output"
+reset_scenario_state
+unset WRK_MALFORMED_ROUTE
+export WRK_FAIL_ROUTE="route-c"
+if run_concurrent_uneven_routes >"${TEST_DIR}/failed.out" 2>"${TEST_DIR}/failed.err"; then
+    fail "failed route process unexpectedly succeeded"
+fi
+grep -q 'concurrent uneven route wrk failed: route-a=0 route-b=0 route-c=17' "${TEST_DIR}/failed.err" || {
+    cat "${TEST_DIR}/failed.err" >&2
+    fail "missing child-status diagnostic"
+}
+grep -q 'forced failure for route-c' "${TEST_DIR}/failed.err" || {
+    cat "${TEST_DIR}/failed.err" >&2
+    fail "missing failed-route raw output"
+}
+
+echo "PASS: upstream-pool matrix concurrent route tests"

--- a/benchmarks/competitive/upstream-pool-matrix.sh
+++ b/benchmarks/competitive/upstream-pool-matrix.sh
@@ -23,26 +23,6 @@ TLS_ORIGIN_PID=""
 ORIGIN_PIDS=()
 LOCK_METRICS=false
 
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --binary) BINARY="$2"; shift 2 ;;
-        --listen-port) LISTEN_PORT="$2"; shift 2 ;;
-        --origin-base-port) ORIGIN_BASE_PORT="$2"; shift 2 ;;
-        --duration) DURATION="$2"; shift 2 ;;
-        --connections) CONNECTIONS="$2"; shift 2 ;;
-        --threads) THREADS="$2"; shift 2 ;;
-        --output) OUTPUT="$2"; shift 2 ;;
-        --help) sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
-        *) echo "unknown arg: $1" >&2; exit 2 ;;
-    esac
-done
-
-[[ -n "$OUTPUT" ]] || { echo "--output is required" >&2; exit 1; }
-for tool in wrk curl python3 jq awk ps pgrep openssl k6; do
-    command -v "$tool" >/dev/null 2>&1 || { echo "missing required tool: $tool" >&2; exit 1; }
-done
-[[ -x "$BINARY" ]] || { echo "tardi binary not found at ${BINARY}" >&2; exit 1; }
-
 cleanup() {
     local status=$?
     if [[ "$status" -ne 0 && -n "$TMP_DIR" && -f "${TMP_DIR}/tardigrade.log" ]]; then
@@ -65,8 +45,6 @@ cleanup() {
     [[ -n "$TMP_DIR" ]] && rm -rf "$TMP_DIR"
     exit "$status"
 }
-trap cleanup EXIT
-
 monotonic_ns() {
     python3 -c 'import time; print(time.monotonic_ns())'
 }
@@ -333,6 +311,223 @@ run_measured_wrk() {
     scenario_json "$rps" "$p99" "$p99_ttfb" "$errors" "$cpu_pct" "$rss_mb" "$open_fds" "$before" "$after" "$elapsed"
 }
 
+route_result_json() {
+    local label="$1" raw_file="$2" duration="$3" connections="$4" threads="$5" requested_share="$6" total_rps="$7" elapsed="$8"
+    local raw summary rps p99 errors request_count achieved_share
+    raw="$(cat "$raw_file")"
+    summary="$(printf '%s\n' "$raw" | sed -n 's/^WRK_SUMMARY //p' | tail -1)"
+    if [[ -z "$summary" ]]; then
+        echo "missing wrk summary for ${label}" >&2
+        echo "$raw" >&2
+        return 1
+    fi
+    rps="$(jq -r '.rps // 0' <<<"$summary")"
+    p99="$(jq -r '.p99_ms // null' <<<"$summary")"
+    errors="$(printf '%s\n' "$raw" | wrk_error_count)"
+    if ! awk -v rps="$rps" 'BEGIN { exit !(rps > 0) }'; then
+        echo "wrk reported non-positive rps for ${label}: ${rps}" >&2
+        echo "$raw" >&2
+        return 1
+    fi
+    if [[ "$errors" != "0" ]]; then
+        echo "wrk reported ${errors} errors for ${label}" >&2
+        echo "$raw" >&2
+        return 1
+    fi
+    request_count="$(awk -v rps="$rps" -v elapsed="$elapsed" 'BEGIN { if (rps > 0 && elapsed > 0) printf "%.0f", rps * elapsed; else print 0 }')"
+    achieved_share="$(awk -v rps="$rps" -v total="$total_rps" 'BEGIN { if (total > 0) printf "%.6f", rps / total; else print 0 }')"
+    jq -n \
+        --argjson requested_share "$requested_share" \
+        --argjson achieved_share "$achieved_share" \
+        --argjson rps "$rps" \
+        --argjson p99 "$p99" \
+        --argjson errors "$errors" \
+        --argjson duration "$duration" \
+        --argjson connections "$connections" \
+        --argjson threads "$threads" \
+        --argjson request_count "$request_count" \
+        '{
+            requested_share: $requested_share,
+            achieved_share: $achieved_share,
+            rps: $rps,
+            p99_ms: $p99,
+            errors: $errors,
+            configured_duration_s: $duration,
+            configured_connections: $connections,
+            configured_threads: $threads,
+            achieved_request_count: $request_count
+        }'
+}
+
+run_concurrent_uneven_routes() {
+    local label="uneven-route-distribution"
+    local duration="$DURATION"
+    local route_a_connections=16 route_a_threads=4 route_a_share=0.80
+    local route_b_connections=3 route_b_threads=1 route_b_share=0.15
+    local route_c_connections=1 route_c_threads=1 route_c_share=0.05
+    local before after mon_pid mon_file cpu_before start_ns end_ns elapsed cpu_pct rss_mb open_fds
+    local route_a_raw route_b_raw route_c_raw route_a_status_file route_b_status_file route_c_status_file
+    local route_a_pid route_b_pid route_c_pid route_a_done=false route_b_done=false route_c_done=false remaining=3 failed=0
+    local route_a_status=0 route_b_status=0 route_c_status=0 route_a_summary route_b_summary route_c_summary
+    local route_a_rps route_b_rps route_c_rps total_rps total_errors combined route_a route_b route_c
+    before="${TMP_DIR}/${label}-before.metrics"
+    after="${TMP_DIR}/${label}-after.metrics"
+    route_a_raw="${TMP_DIR}/${label}-route-a.wrk"
+    route_b_raw="${TMP_DIR}/${label}-route-b.wrk"
+    route_c_raw="${TMP_DIR}/${label}-route-c.wrk"
+    route_a_status_file="${TMP_DIR}/${label}-route-a.status"
+    route_b_status_file="${TMP_DIR}/${label}-route-b.status"
+    route_c_status_file="${TMP_DIR}/${label}-route-c.status"
+
+    current_metrics > "$before"
+    read -r mon_pid mon_file cpu_before start_ns < <(start_monitor)
+
+    (
+        wrk --latency -s "${BENCH_DIR}/wrk-summary.lua" -t"${route_a_threads}" -c"${route_a_connections}" -d"${duration}s" "http://127.0.0.1:${LISTEN_PORT}/route-a" >"$route_a_raw" 2>&1 &
+        child_pid="$!"
+        trap 'kill "$child_pid" 2>/dev/null || true; wait "$child_pid" 2>/dev/null || true; exit 143' TERM INT
+        wait "$child_pid"
+        printf '%s\n' "$?" > "$route_a_status_file"
+    ) &
+    route_a_pid="$!"
+    (
+        wrk --latency -s "${BENCH_DIR}/wrk-summary.lua" -t"${route_b_threads}" -c"${route_b_connections}" -d"${duration}s" "http://127.0.0.1:${LISTEN_PORT}/route-b" >"$route_b_raw" 2>&1 &
+        child_pid="$!"
+        trap 'kill "$child_pid" 2>/dev/null || true; wait "$child_pid" 2>/dev/null || true; exit 143' TERM INT
+        wait "$child_pid"
+        printf '%s\n' "$?" > "$route_b_status_file"
+    ) &
+    route_b_pid="$!"
+    (
+        wrk --latency -s "${BENCH_DIR}/wrk-summary.lua" -t"${route_c_threads}" -c"${route_c_connections}" -d"${duration}s" "http://127.0.0.1:${LISTEN_PORT}/route-c" >"$route_c_raw" 2>&1 &
+        child_pid="$!"
+        trap 'kill "$child_pid" 2>/dev/null || true; wait "$child_pid" 2>/dev/null || true; exit 143' TERM INT
+        wait "$child_pid"
+        printf '%s\n' "$?" > "$route_c_status_file"
+    ) &
+    route_c_pid="$!"
+
+    while [[ "$remaining" -gt 0 ]]; do
+        if ! $route_a_done && [[ -f "$route_a_status_file" ]]; then
+            route_a_status="$(cat "$route_a_status_file")"
+            route_a_done=true
+            remaining=$((remaining - 1))
+            if [[ "$route_a_status" -ne 0 ]]; then
+                failed=1
+                if ! $route_b_done; then
+                    kill "$route_b_pid" 2>/dev/null || true
+                    route_b_status=143
+                    route_b_done=true
+                    remaining=$((remaining - 1))
+                fi
+                if ! $route_c_done; then
+                    kill "$route_c_pid" 2>/dev/null || true
+                    route_c_status=143
+                    route_c_done=true
+                    remaining=$((remaining - 1))
+                fi
+            fi
+        fi
+        if ! $route_b_done && [[ -f "$route_b_status_file" ]]; then
+            route_b_status="$(cat "$route_b_status_file")"
+            route_b_done=true
+            remaining=$((remaining - 1))
+            if [[ "$route_b_status" -ne 0 ]]; then
+                failed=1
+                if ! $route_a_done; then
+                    kill "$route_a_pid" 2>/dev/null || true
+                    route_a_status=143
+                    route_a_done=true
+                    remaining=$((remaining - 1))
+                fi
+                if ! $route_c_done; then
+                    kill "$route_c_pid" 2>/dev/null || true
+                    route_c_status=143
+                    route_c_done=true
+                    remaining=$((remaining - 1))
+                fi
+            fi
+        fi
+        if ! $route_c_done && [[ -f "$route_c_status_file" ]]; then
+            route_c_status="$(cat "$route_c_status_file")"
+            route_c_done=true
+            remaining=$((remaining - 1))
+            if [[ "$route_c_status" -ne 0 ]]; then
+                failed=1
+                if ! $route_a_done; then
+                    kill "$route_a_pid" 2>/dev/null || true
+                    route_a_status=143
+                    route_a_done=true
+                    remaining=$((remaining - 1))
+                fi
+                if ! $route_b_done; then
+                    kill "$route_b_pid" 2>/dev/null || true
+                    route_b_status=143
+                    route_b_done=true
+                    remaining=$((remaining - 1))
+                fi
+            fi
+        fi
+        [[ "$remaining" -eq 0 ]] || sleep 0.05
+    done
+    wait "$route_a_pid" 2>/dev/null || true
+    wait "$route_b_pid" 2>/dev/null || true
+    wait "$route_c_pid" 2>/dev/null || true
+    end_ns="$(monotonic_ns)"
+    read -r cpu_pct rss_mb open_fds < <(stop_monitor "$mon_pid" "$mon_file" "$cpu_before" "$start_ns")
+    current_metrics > "$after"
+
+    if [[ "$failed" -ne 0 || "$route_a_status" -ne 0 || "$route_b_status" -ne 0 || "$route_c_status" -ne 0 ]]; then
+        echo "concurrent uneven route wrk failed: route-a=${route_a_status} route-b=${route_b_status} route-c=${route_c_status}" >&2
+        echo "---- route-a wrk output ----" >&2
+        cat "$route_a_raw" >&2
+        echo "---- route-b wrk output ----" >&2
+        cat "$route_b_raw" >&2
+        echo "---- route-c wrk output ----" >&2
+        cat "$route_c_raw" >&2
+        return 1
+    fi
+
+    route_a_summary="$(sed -n 's/^WRK_SUMMARY //p' "$route_a_raw" | tail -1)"
+    route_b_summary="$(sed -n 's/^WRK_SUMMARY //p' "$route_b_raw" | tail -1)"
+    route_c_summary="$(sed -n 's/^WRK_SUMMARY //p' "$route_c_raw" | tail -1)"
+    if [[ -z "$route_a_summary" || -z "$route_b_summary" || -z "$route_c_summary" ]]; then
+        [[ -n "$route_a_summary" ]] || { echo "missing wrk summary for route-a" >&2; cat "$route_a_raw" >&2; }
+        [[ -n "$route_b_summary" ]] || { echo "missing wrk summary for route-b" >&2; cat "$route_b_raw" >&2; }
+        [[ -n "$route_c_summary" ]] || { echo "missing wrk summary for route-c" >&2; cat "$route_c_raw" >&2; }
+        return 1
+    fi
+    route_a_rps="$(jq -r '.rps // 0' <<<"$route_a_summary")"
+    route_b_rps="$(jq -r '.rps // 0' <<<"$route_b_summary")"
+    route_c_rps="$(jq -r '.rps // 0' <<<"$route_c_summary")"
+    total_rps="$(awk -v a="$route_a_rps" -v b="$route_b_rps" -v c="$route_c_rps" 'BEGIN { printf "%.3f", a + b + c }')"
+    elapsed="$(awk -v s="$start_ns" -v e="$end_ns" 'BEGIN { printf "%.3f", (e - s) / 1000000000 }')"
+
+    route_a="$(route_result_json route-a "$route_a_raw" "$duration" "$route_a_connections" "$route_a_threads" "$route_a_share" "$total_rps" "$elapsed")"
+    route_b="$(route_result_json route-b "$route_b_raw" "$duration" "$route_b_connections" "$route_b_threads" "$route_b_share" "$total_rps" "$elapsed")"
+    route_c="$(route_result_json route-c "$route_c_raw" "$duration" "$route_c_connections" "$route_c_threads" "$route_c_share" "$total_rps" "$elapsed")"
+    total_errors="$(jq -n --argjson a "$route_a" --argjson b "$route_b" --argjson c "$route_c" '($a.errors // 0) + ($b.errors // 0) + ($c.errors // 0)')"
+    combined="$(scenario_json "$total_rps" null null "$total_errors" "$cpu_pct" "$rss_mb" "$open_fds" "$before" "$after" "$elapsed")"
+
+    jq -n \
+        --argjson route_a "$route_a" \
+        --argjson route_b "$route_b" \
+        --argjson route_c "$route_c" \
+        --argjson combined "$combined" \
+        '{
+            covered: true,
+            concurrent: true,
+            note: "Routes were measured under one concurrent wrk window. Route-local rps, p99, errors, and achieved shares come from each wrk process; CPU, RSS, fd, upstream reuse, and lock-wait metrics are process-wide combined-window measurements.",
+            routes: {
+                route_a: $route_a,
+                route_b: $route_b,
+                route_c: $route_c
+            },
+            combined: $combined,
+            errors: (($route_a.errors // 0) + ($route_b.errors // 0) + ($route_c.errors // 0))
+        }'
+}
+
 start_gateway() {
     local workers="$1"
     [[ -n "$TARDIGRADE_PID" ]] && { kill "$TARDIGRADE_PID" 2>/dev/null || true; wait "$TARDIGRADE_PID" 2>/dev/null || true; }
@@ -396,6 +591,28 @@ worker_sweep_json() {
     }'
 }
 
+main() {
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --binary) BINARY="$2"; shift 2 ;;
+        --listen-port) LISTEN_PORT="$2"; shift 2 ;;
+        --origin-base-port) ORIGIN_BASE_PORT="$2"; shift 2 ;;
+        --duration) DURATION="$2"; shift 2 ;;
+        --connections) CONNECTIONS="$2"; shift 2 ;;
+        --threads) THREADS="$2"; shift 2 ;;
+        --output) OUTPUT="$2"; shift 2 ;;
+        --help) sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+[[ -n "$OUTPUT" ]] || { echo "--output is required" >&2; exit 1; }
+for tool in wrk curl python3 jq awk ps pgrep openssl k6; do
+    command -v "$tool" >/dev/null 2>&1 || { echo "missing required tool: $tool" >&2; exit 1; }
+done
+[[ -x "$BINARY" ]] || { echo "tardi binary not found at ${BINARY}" >&2; exit 1; }
+trap cleanup EXIT
+
 TMP_DIR="$(mktemp -d /tmp/tardigrade-upstream-matrix-XXXXXX)"
 CONFIG_FILE="${TMP_DIR}/upstream-matrix.conf"
 TLS_ORIGIN_PORT=$((ORIGIN_BASE_PORT + 40))
@@ -457,9 +674,7 @@ for ((i = 0; i < ORIGIN_COUNT; i += 1)); do
 done
 
 hot_json="$(run_measured_wrk hot-origin hot "$DURATION" "$CONNECTIONS" "$THREADS" true)"
-route_a_json="$hot_json"
-route_b_json="$(run_measured_wrk route-b route-b 2 4 1 false)"
-route_c_json="$(run_measured_wrk route-c route-c 1 2 1 false)"
+uneven_routes_json="$(run_concurrent_uneven_routes)"
 
 origins_before="${TMP_DIR}/origins-before.metrics"
 origins_after="${TMP_DIR}/origins-after.metrics"
@@ -512,9 +727,7 @@ jq -n \
     --argjson duration "$DURATION" \
     --argjson threads "$THREADS" \
     --argjson hot "$hot_json" \
-    --argjson route_a "$route_a_json" \
-    --argjson route_b "$route_b_json" \
-    --argjson route_c "$route_c_json" \
+    --argjson uneven_routes "$uneven_routes_json" \
     --argjson origins_aggregate "$origins_aggregate" \
     --argjson origins "$origins_json" \
     --argjson tls "$tls_json" \
@@ -527,16 +740,7 @@ jq -n \
             note: "p99_ttfb_ms is measured from k6 http_req_waiting where present; p99_ms is wrk end-to-end latency."
         },
         scenarios: {
-            "uneven-route-distribution": {
-                covered: false,
-                reason: "route-a/b/c run as three sequential wrk passes, not concurrent mixed traffic — they never compete for the shared worker/connection pool at the same time, so this does not exercise or validate route-fairness under concurrent uneven traffic as #149/#593 require. Per-route numbers below are real, informational single-route measurements, not fairness evidence. See https://github.com/Bare-Systems/Tardigrade/issues/683.",
-                routes: {
-                    "route-a-hot": ($route_a + {requested_weight: 80}),
-                    "route-b-warm": ($route_b + {requested_weight: 15}),
-                    "route-c-cold": ($route_c + {requested_weight: 5})
-                },
-                errors: (($route_a.errors // 0) + ($route_b.errors // 0) + ($route_c.errors // 0))
-            },
+            "uneven-route-distribution": $uneven_routes,
             "many-origins-low-volume": ($origins_aggregate + {
                 covered: (($origins | map(.errors // 0) | add) == 0),
                 origins: ($origins | length),
@@ -551,3 +755,8 @@ jq -n \
     }' > "$OUTPUT"
 
 echo "Wrote upstream-pool matrix: ${OUTPUT}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/benchmarks/competitive/upstream-pool-matrix.sh
+++ b/benchmarks/competitive/upstream-pool-matrix.sh
@@ -312,8 +312,8 @@ run_measured_wrk() {
 }
 
 route_result_json() {
-    local label="$1" raw_file="$2" duration="$3" connections="$4" threads="$5" requested_share="$6" total_rps="$7" elapsed="$8"
-    local raw summary rps p99 errors request_count achieved_share
+    local label="$1" raw_file="$2" duration="$3" connections="$4" threads="$5" requested_share="$6" total_rps="$7"
+    local raw summary rps p99 errors achieved_share
     raw="$(cat "$raw_file")"
     summary="$(printf '%s\n' "$raw" | sed -n 's/^WRK_SUMMARY //p' | tail -1)"
     if [[ -z "$summary" ]]; then
@@ -334,7 +334,6 @@ route_result_json() {
         echo "$raw" >&2
         return 1
     fi
-    request_count="$(awk -v rps="$rps" -v elapsed="$elapsed" 'BEGIN { if (rps > 0 && elapsed > 0) printf "%.0f", rps * elapsed; else print 0 }')"
     achieved_share="$(awk -v rps="$rps" -v total="$total_rps" 'BEGIN { if (total > 0) printf "%.6f", rps / total; else print 0 }')"
     jq -n \
         --argjson requested_share "$requested_share" \
@@ -345,7 +344,6 @@ route_result_json() {
         --argjson duration "$duration" \
         --argjson connections "$connections" \
         --argjson threads "$threads" \
-        --argjson request_count "$request_count" \
         '{
             requested_share: $requested_share,
             achieved_share: $achieved_share,
@@ -354,9 +352,24 @@ route_result_json() {
             errors: $errors,
             configured_duration_s: $duration,
             configured_connections: $connections,
-            configured_threads: $threads,
-            achieved_request_count: $request_count
+            configured_threads: $threads
         }'
+}
+
+run_wrk_to_status_file() {
+    local raw_file="$1" status_file="$2" threads="$3" connections="$4" duration="$5" path="$6"
+    local child_pid status status_tmp
+    wrk --latency -s "${BENCH_DIR}/wrk-summary.lua" -t"${threads}" -c"${connections}" -d"${duration}s" "http://127.0.0.1:${LISTEN_PORT}/${path}" >"$raw_file" 2>&1 &
+    child_pid="$!"
+    trap 'kill "$child_pid" 2>/dev/null || true; wait "$child_pid" 2>/dev/null || true; exit 143' TERM INT
+    if wait "$child_pid"; then
+        status=0
+    else
+        status=$?
+    fi
+    status_tmp="${status_file}.tmp.$$"
+    printf '%s\n' "$status" > "$status_tmp"
+    mv "$status_tmp" "$status_file"
 }
 
 run_concurrent_uneven_routes() {
@@ -382,29 +395,11 @@ run_concurrent_uneven_routes() {
     current_metrics > "$before"
     read -r mon_pid mon_file cpu_before start_ns < <(start_monitor)
 
-    (
-        wrk --latency -s "${BENCH_DIR}/wrk-summary.lua" -t"${route_a_threads}" -c"${route_a_connections}" -d"${duration}s" "http://127.0.0.1:${LISTEN_PORT}/route-a" >"$route_a_raw" 2>&1 &
-        child_pid="$!"
-        trap 'kill "$child_pid" 2>/dev/null || true; wait "$child_pid" 2>/dev/null || true; exit 143' TERM INT
-        wait "$child_pid"
-        printf '%s\n' "$?" > "$route_a_status_file"
-    ) &
+    run_wrk_to_status_file "$route_a_raw" "$route_a_status_file" "$route_a_threads" "$route_a_connections" "$duration" route-a &
     route_a_pid="$!"
-    (
-        wrk --latency -s "${BENCH_DIR}/wrk-summary.lua" -t"${route_b_threads}" -c"${route_b_connections}" -d"${duration}s" "http://127.0.0.1:${LISTEN_PORT}/route-b" >"$route_b_raw" 2>&1 &
-        child_pid="$!"
-        trap 'kill "$child_pid" 2>/dev/null || true; wait "$child_pid" 2>/dev/null || true; exit 143' TERM INT
-        wait "$child_pid"
-        printf '%s\n' "$?" > "$route_b_status_file"
-    ) &
+    run_wrk_to_status_file "$route_b_raw" "$route_b_status_file" "$route_b_threads" "$route_b_connections" "$duration" route-b &
     route_b_pid="$!"
-    (
-        wrk --latency -s "${BENCH_DIR}/wrk-summary.lua" -t"${route_c_threads}" -c"${route_c_connections}" -d"${duration}s" "http://127.0.0.1:${LISTEN_PORT}/route-c" >"$route_c_raw" 2>&1 &
-        child_pid="$!"
-        trap 'kill "$child_pid" 2>/dev/null || true; wait "$child_pid" 2>/dev/null || true; exit 143' TERM INT
-        wait "$child_pid"
-        printf '%s\n' "$?" > "$route_c_status_file"
-    ) &
+    run_wrk_to_status_file "$route_c_raw" "$route_c_status_file" "$route_c_threads" "$route_c_connections" "$duration" route-c &
     route_c_pid="$!"
 
     while [[ "$remaining" -gt 0 ]]; do
@@ -503,9 +498,9 @@ run_concurrent_uneven_routes() {
     total_rps="$(awk -v a="$route_a_rps" -v b="$route_b_rps" -v c="$route_c_rps" 'BEGIN { printf "%.3f", a + b + c }')"
     elapsed="$(awk -v s="$start_ns" -v e="$end_ns" 'BEGIN { printf "%.3f", (e - s) / 1000000000 }')"
 
-    route_a="$(route_result_json route-a "$route_a_raw" "$duration" "$route_a_connections" "$route_a_threads" "$route_a_share" "$total_rps" "$elapsed")"
-    route_b="$(route_result_json route-b "$route_b_raw" "$duration" "$route_b_connections" "$route_b_threads" "$route_b_share" "$total_rps" "$elapsed")"
-    route_c="$(route_result_json route-c "$route_c_raw" "$duration" "$route_c_connections" "$route_c_threads" "$route_c_share" "$total_rps" "$elapsed")"
+    route_a="$(route_result_json route-a "$route_a_raw" "$duration" "$route_a_connections" "$route_a_threads" "$route_a_share" "$total_rps")"
+    route_b="$(route_result_json route-b "$route_b_raw" "$duration" "$route_b_connections" "$route_b_threads" "$route_b_share" "$total_rps")"
+    route_c="$(route_result_json route-c "$route_c_raw" "$duration" "$route_c_connections" "$route_c_threads" "$route_c_share" "$total_rps")"
     total_errors="$(jq -n --argjson a "$route_a" --argjson b "$route_b" --argjson c "$route_c" '($a.errors // 0) + ($b.errors // 0) + ($c.errors // 0)')"
     combined="$(scenario_json "$total_rps" null null "$total_errors" "$cpu_pct" "$rss_mb" "$open_fds" "$before" "$after" "$elapsed")"
 


### PR DESCRIPTION
## Summary

- replace the uneven-route-distribution alias/sequential route runs with one concurrent route-a/route-b/route-c wrk window
- record per-route wrk rps/p99/errors/config/achieved shares separately from combined process-wide pool/CPU/RSS/fd metrics
- add a deterministic benchmark harness test with a fake wrk barrier and wire it into CI shellcheck/test coverage

Fixes #683

## Validation

- bash -n benchmarks/competitive/upstream-pool-matrix.sh benchmarks/competitive/test-upstream-pool-matrix.sh
- shellcheck benchmarks/competitive/upstream-pool-matrix.sh benchmarks/competitive/test-upstream-pool-matrix.sh
- ./benchmarks/competitive/test-upstream-pool-matrix.sh